### PR TITLE
Data table api views, api updates

### DIFF
--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -127,6 +127,7 @@ class ExampleMessageSerializer(serializers.Serializer):
     ::
 
         {
+            "dataset": 2,
             "filters": [
                 {
                     "dimension": "time",
@@ -157,7 +158,7 @@ class ExampleMessageSerializer(serializers.Serializer):
             ]
         }
     """
-
+    dataset = dataset = serializers.PrimaryKeyRelatedField(queryset=corpus_models.Dataset.objects.all())
     filters = serializers.ListField(child=FilterSerializer(), required=False)
     focus = serializers.ListField(child=FilterSerializer(), required=False)
     messages = serializers.ListField(child=MessageSerializer(), required=False, read_only=True)

--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -18,6 +18,68 @@ import msgvis.apps.questions.models as questions_models
 from msgvis.apps.dimensions import registry
 
 
+# A simple string field that looks up dimensions on deserialization
+class DimensionKeySerializer(serializers.CharField):
+    def to_internal_value(self, data):
+        return registry.get_dimension(data)
+
+    def to_representation(self, instance):
+        return instance.key
+
+
+class FilterSerializer(serializers.Serializer):
+    """
+    Filters indicate a subset of the range of a specific dimension. Below is
+    an array of three filter objects.
+
+    ::
+
+        [{
+          "dimension": 'time',
+          "min_time": "2010-02-25T00:23:53Z",
+          "max_time": "2010-02-30T00:23:53Z"
+        },
+        {
+          "dimension": 'words',
+          "levels": [
+            "cat",
+            "dog",
+            "alligator"
+          ]
+        },
+        {
+          "dimension": 'reply_count',
+          "max": 100
+        }]
+
+    Although every filter has a ``dimension`` field, the specific properties
+    vary depending on the type of the dimension and the kind of filter.
+
+    At this time, there are three types of filters:
+
+    -  Quantitative dimensions can be filtered using one or both of the
+       ``min`` and ``max`` properties (inclusive).
+    -  The time dimension can be filtered using one or both of the ``min_time``
+       and ``max_time`` properties (inclusive).
+    -  Categorical dimensions can be filtered by specifying an ``include``
+       list. All other items are assumed to be excluded.
+
+    The 'value' field may also be used for exact matches.
+    """
+
+    dimension = DimensionKeySerializer()
+
+    min = serializers.FloatField(required=False)
+    max = serializers.FloatField(required=False)
+
+    min_time = serializers.DateTimeField(required=False)
+    max_time = serializers.DateTimeField(required=False)
+
+    levels = serializers.ListSerializer(child=serializers.CharField(), required=False)
+
+    value = serializers.CharField(required=False)
+
+
 class PersonSerializer(serializers.ModelSerializer):
     class Meta:
         model = corpus_models.Person
@@ -57,6 +119,7 @@ class MessageSerializer(serializers.ModelSerializer):
         model = corpus_models.Message
         fields = ('id', 'dataset', 'text', 'sender', 'time')
 
+
 class ExampleMessageSerializer(serializers.Serializer):
     """
     Example message requests.
@@ -95,8 +158,8 @@ class ExampleMessageSerializer(serializers.Serializer):
         }
     """
 
-    filters = serializers.ListField(child=serializers.DictField(), required=False)
-    focus = serializers.ListField(child=serializers.DictField(), required=False)
+    filters = serializers.ListField(child=FilterSerializer(), required=False)
+    focus = serializers.ListField(child=FilterSerializer(), required=False)
     messages = serializers.ListField(child=MessageSerializer(), required=False, read_only=True)
 
 
@@ -199,64 +262,6 @@ class DimensionSerializer(serializers.Serializer):
         return registry.get_dimension(data['key'])
 
 
-# A simple string field that looks up dimensions on deserialization
-class DimensionKeySerializer(serializers.CharField):
-    def to_internal_value(self, data):
-        return registry.get_dimension(data)
-
-    def to_representation(self, instance):
-        return instance.key
-
-
-class FilterSerializer(serializers.Serializer):
-    """
-    Filters indicate a subset of the range of a specific dimension. Below is
-    an array of three filter objects.
-
-    ::
-
-        [{
-          "dimension": 'time',
-          "min_time": "2010-02-25T00:23:53Z",
-          "max_time": "2010-02-30T00:23:53Z"
-        },
-        {
-          "dimension": 'words',
-          "levels": [
-            "cat",
-            "dog",
-            "alligator"
-          ]
-        },
-        {
-          "dimension": 'reply_count',
-          "max": 100
-        }]
-
-    Although every filter has a ``dimension`` field, the specific properties
-    vary depending on the type of the dimension and the kind of filter.
-
-    At this time, there are three types of filters:
-
-    -  Quantitative dimensions can be filtered using one or both of the
-       ``min`` and ``max`` properties (inclusive).
-    -  The time dimension can be filtered using one or both of the ``min_time``
-       and ``max_time`` properties (inclusive).
-    -  Categorical dimensions can be filtered by specifying an ``include``
-       list. All other items are assumed to be excluded.
-    """
-
-    dimension = DimensionKeySerializer()
-
-    min = serializers.FloatField(required=False)
-    max = serializers.FloatField(required=False)
-
-    min_time = serializers.DateTimeField(required=False)
-    max_time = serializers.DateTimeField(required=False)
-
-    levels = serializers.ListSerializer(child=serializers.CharField(), required=False)
-
-
 class DimensionDistributionSerializer(serializers.Serializer):
     """
     Dimension distribution requests.
@@ -291,3 +296,47 @@ class DimensionDistributionSerializer(serializers.Serializer):
     dataset = serializers.PrimaryKeyRelatedField(queryset=corpus_models.Dataset.objects.all())
     dimension = DimensionKeySerializer()
     distribution = serializers.ListField(child=serializers.DictField(), required=False, read_only=True)
+
+
+class DataTableSerializer(serializers.Serializer):
+    """
+    Format for data table requests.
+    Post these without the result key.
+
+    ::
+
+        {
+          "dataset": 2,
+          "dimensions": ['time'],
+          "filters": [
+            {
+              "dimension": 'time',
+              "min": "2010-02-25T00:23:53Z",
+              "max": "2010-02-30T00:23:53Z"
+            }
+          ],
+          "result": [
+            {
+              "value": 35,
+              "time": "2010-02-25T00:23:53Z"
+            },
+            {
+              "value": 35,
+              "time": "2010-02-26T00:23:53Z"
+            },
+            {
+              "value": 35,
+              "time": "2010-02-27T00:23:53Z"
+            },
+            {
+              "value": 35,
+              "time": "2010-02-28T00:23:53Z"
+            }
+          ]
+        }
+    """
+
+    dataset = serializers.PrimaryKeyRelatedField(queryset=corpus_models.Dataset.objects.all())
+    dimensions = serializers.ListField(child=DimensionKeySerializer())
+    filters = serializers.ListField(child=FilterSerializer(), required=False)
+    result = serializers.ListField(child=serializers.DictField(), required=False, read_only=True)

--- a/msgvis/apps/api/tests/__init__.py
+++ b/msgvis/apps/api/tests/__init__.py
@@ -1,0 +1,6 @@
+def api_time_format(dt):
+    """Convert a datetime to string according to the API settings"""
+    from rest_framework.fields import DateTimeField
+
+    field = DateTimeField()
+    return field.to_representation(dt)

--- a/msgvis/apps/api/tests/test_views.py
+++ b/msgvis/apps/api/tests/test_views.py
@@ -3,17 +3,17 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 
 from msgvis.apps.corpus import models as corpus_models
+from msgvis.apps.questions import models as questions_models
+from msgvis.apps.dimensions import models as dimensions_models
 import mock
 
 
 class DimensionDistributionViewTest(APITestCase):
-
     def setUp(self):
         self.dataset = corpus_models.Dataset.objects.create(name="Api test dataset")
 
     @mock.patch('msgvis.apps.dimensions.registry.get_dimension')
     def test_get_count_distribution(self, get_dimension):
-
         # Fake the dimension internally
         dimension = mock.Mock()
         dimension.key = 'time'
@@ -58,3 +58,70 @@ class DimensionDistributionViewTest(APITestCase):
         dimension.get_distribution.assert_called_once_with(self.dataset)
         self.assertEquals(response.data, expected_response)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
+
+
+class ResearchQuestionsViewTest(APITestCase):
+    def setUp(self):
+        self.dataset = corpus_models.Dataset.objects.create(name="Api test dataset")
+
+    @mock.patch('msgvis.apps.questions.models.Question.get_sample_questions')
+    def test_get_count_distribution(self, get_sample_questions):
+        primary_dimension_key = 'time'
+        secondary_dimension_key = 'hashtags'
+
+        # Mock the sample questions (sadly this requires a ton of models)
+        article = questions_models.Article.objects.create(
+            authors="something",
+            link="a link",
+            title="some title",
+            venue="a venue"
+        )
+        primary_dim = dimensions_models.DimensionKey.objects.create(key=primary_dimension_key)
+        secondary_dim = dimensions_models.DimensionKey.objects.create(key=secondary_dimension_key)
+        sample_questions = [
+            questions_models.Question.objects.create(
+                text="hello",
+                source=article,
+            ),
+            questions_models.Question.objects.create(
+                text="goodbye",
+                source=article,
+            ),
+        ]
+        for q in sample_questions:
+            q.dimensions.add(primary_dim)
+            q.dimensions.add(secondary_dim)
+
+        get_sample_questions.return_value = sample_questions
+
+        url = reverse('research-questions')
+        data = {
+            "dimensions": [primary_dimension_key, secondary_dimension_key]
+        }
+
+        expected_response = {
+            'dimensions': [primary_dimension_key, secondary_dimension_key],
+            'questions': [
+                {
+                    'id': q.id,
+                    'text': q.text,
+                    'dimensions': [d.key for d in q.dimensions.all()],
+                    'source': {
+                        'id': q.source.id,
+                        'authors': q.source.authors,
+                        'link': q.source.link,
+                        'title': q.source.title,
+                        'year': q.source.year,
+                        'venue': q.source.venue,
+                    }
+                } for q in sample_questions
+            ]
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        get_sample_questions.assert_called_once_with(primary_dimension_key, secondary_dimension_key)
+
+        self.assertEquals(response.data, expected_response)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+

--- a/msgvis/apps/api/tests/test_views.py
+++ b/msgvis/apps/api/tests/test_views.py
@@ -64,21 +64,21 @@ class ResearchQuestionsViewTest(APITestCase):
     def setUp(self):
         self.dataset = corpus_models.Dataset.objects.create(name="Api test dataset")
 
-    @mock.patch('msgvis.apps.questions.models.Question.get_sample_questions')
-    def test_get_count_distribution(self, get_sample_questions):
-        primary_dimension_key = 'time'
-        secondary_dimension_key = 'hashtags'
+        # Create some dimension keys
+        self.dimension_keys = ['time', 'hashtags']
+        primary_dim = dimensions_models.DimensionKey.objects.create(key=self.dimension_keys[0])
+        secondary_dim = dimensions_models.DimensionKey.objects.create(key=self.dimension_keys[1])
 
-        # Mock the sample questions (sadly this requires a ton of models)
+        # Create an article
         article = questions_models.Article.objects.create(
             authors="something",
             link="a link",
             title="some title",
             venue="a venue"
         )
-        primary_dim = dimensions_models.DimensionKey.objects.create(key=primary_dimension_key)
-        secondary_dim = dimensions_models.DimensionKey.objects.create(key=secondary_dimension_key)
-        sample_questions = [
+
+        # Generate some sample research questions
+        self.sample_questions = [
             questions_models.Question.objects.create(
                 text="hello",
                 source=article,
@@ -88,11 +88,17 @@ class ResearchQuestionsViewTest(APITestCase):
                 source=article,
             ),
         ]
-        for q in sample_questions:
+
+        for q in self.sample_questions:
             q.dimensions.add(primary_dim)
             q.dimensions.add(secondary_dim)
 
-        get_sample_questions.return_value = sample_questions
+    @mock.patch('msgvis.apps.questions.models.Question.get_sample_questions')
+    def test_get_count_distribution(self, get_sample_questions):
+        primary_dimension_key = self.dimension_keys[0]
+        secondary_dimension_key = self.dimension_keys[1]
+
+        get_sample_questions.return_value = self.sample_questions
 
         url = reverse('research-questions')
         data = {
@@ -114,7 +120,7 @@ class ResearchQuestionsViewTest(APITestCase):
                         'year': q.source.year,
                         'venue': q.source.venue,
                     }
-                } for q in sample_questions
+                } for q in self.sample_questions
             ]
         }
 
@@ -125,3 +131,77 @@ class ResearchQuestionsViewTest(APITestCase):
         self.assertEquals(response.data, expected_response)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
+
+class ExampleMessagesViewTest(APITestCase):
+    def setUp(self):
+        self.dataset = corpus_models.Dataset.objects.create(name="Api test dataset")
+
+        sender = self.dataset.person_set.create(
+            username='a person',
+            full_name='a more important person',
+            original_id=2353583,
+        )
+
+        # Create a couple of messages
+        self.sample_messages = [
+            self.dataset.message_set.create(
+                text="i am a message",
+                sender=sender,
+            ),
+            self.dataset.message_set.create(
+                text="another message",
+                sender=sender,
+            )
+        ]
+
+
+    @mock.patch('msgvis.apps.corpus.models.Dataset.get_example_messages')
+    def test_get_count_distribution(self, get_example_messages):
+
+        # fake the actual example finding
+        get_example_messages.return_value = self.sample_messages
+
+        url = reverse('example-messages')
+        data = {
+            "filters": [
+                {
+                    "dimension": "time",
+                    "min_time": "2015-02-02T01:19:08Z",
+                    "max_time": "2015-02-02T01:19:09Z"
+                }
+            ],
+            "focus": [
+                {
+                    "dimension": "time",
+                    "value": "2015-02-02T01:19:09Z"
+                }
+            ]
+        }
+
+        expected_response = {
+            "filters": data['filters'],
+            "focus": data['focus'],
+            "messages": [
+                {
+                    'id': m.id,
+                    'dataset': m.dataset_id,
+                    'text': m.text,
+                    'time': m.time,
+                    'sender': {
+                        'id': m.sender.id,
+                        'dataset': m.sender.dataset_id,
+                        'original_id': m.sender.original_id,
+                        'username': m.sender.username,
+                        'full_name': m.sender.full_name,
+                        }
+                } for m in self.sample_messages
+            ]
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        # Should literally use the input data
+        get_example_messages.assert_called_once_with(settings=data)
+
+        self.assertEquals(response.data, expected_response)
+        self.assertEquals(response.status_code, status.HTTP_200_OK)

--- a/msgvis/apps/api/tests/test_views.py
+++ b/msgvis/apps/api/tests/test_views.py
@@ -163,13 +163,15 @@ class ExampleMessagesViewTest(APITestCase):
         ]
 
 
-    @mock.patch('msgvis.apps.corpus.models.Dataset.get_example_messages')
+    @mock.patch.object(corpus_models.Dataset, 'get_example_messages')
     def test_get_example_messages_api(self, get_example_messages):
+
         # fake the actual example finding
         get_example_messages.return_value = self.sample_messages
 
         url = reverse('example-messages')
         data = {
+            "dataset": self.dataset.id,
             "filters": [
                 {
                     "dimension": "time",
@@ -186,6 +188,7 @@ class ExampleMessagesViewTest(APITestCase):
         }
 
         expected_response = {
+            "dataset": data['dataset'],
             "filters": data['filters'],
             "focus": data['focus'],
             "messages": [

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -56,53 +56,9 @@ class DataTableView(APIView):
 
     **Request:** ``POST /api/table``
 
-    **Example Request Body:**
-
-    ::
-
-        {
-          "dimensions": ['time'],
-          "filters": [
-            {
-              "dimension": 'time',
-              "min_time": "2010-02-25T00:23:53Z",
-              "max_time": "2010-02-26T00:23:53Z"
-            }
-          ],
-        }
-
-    **Example Response Body:**
-
-    ::
-
-        {
-          "dimensions": ['time', 'hashtags'],
-          "filters": [
-            {
-              "dimension": 'time',
-              "min": "2010-02-25T00:23:53Z",
-              "max": "2010-02-28T00:23:53Z"
-            }
-          ],
-          "result": [
-            {
-              "value": 35,
-              "time": "2010-02-25T00:23:53Z"
-            },
-            {
-              "value": 35,
-              "time": "2010-02-26T00:23:53Z"
-            },
-            {
-              "value": 35,
-              "time": "2010-02-27T00:23:53Z"
-            },
-            {
-              "value": 35,
-              "time": "2010-02-28T00:23:53Z"
-            }
-          ]
-        }
+    **Format:** The request and response should match
+    :class:`.DataTableSerializer`.
+    Requests should not include the ``result`` key.
     """
 
     def post(self, request, format=None):
@@ -139,34 +95,11 @@ class ExampleMessagesView(APIView):
     Get some example messages matching the current filters and a focus
     within the visualization.
 
-    The request should include a list active filters.
-    It should also include a ``focus`` object that specifies values for one
-    or both of the given dimensions, keyed by name.
-
-    The response will include a list of `message objects <#messages>`_.
-
     **Request:** ``POST /api/messages``
 
-    **Example Request Body:**
-
-    ::
-
-        {
-          "dataset": 2,
-          "filters": [
-            {
-              "dimension": "time",
-              "min_time": "2015-02-02T01:19:08Z",
-              "max_time": "2015-02-02T01:19:09Z"
-            }
-          ],
-          "focus": [
-            {
-              "dimension": "time",
-              "value": "2015-02-02T01:19:09Z"
-            }
-          ]
-        }
+    **Format:**: The request and response should match
+    :class:`.ExampleMessageSerializer`.
+    Requests should not include the ``messages`` key.
     """
 
     def post(self, request, format=None):
@@ -194,31 +127,12 @@ class ExampleMessagesView(APIView):
 class ResearchQuestionsView(APIView):
     """
     Get a list of research questions related to a selection of dimensions and filters.
-    The request should include a list of :class:`.DimensionKey` ids and filter specifications.
-
-    The response will include a list of Research :class:`.Question`.
 
     **Request:** ``POST /api/questions``
 
-    **Example Request Body:**
-
-    ::
-
-        {
-          "dimensions": ["hashtags", "time"]
-        }
-
-    **Example Response:**
-
-    ::
-
-        {
-          "dimensions": ["hashtags", "time"]
-          "questions" [
-            { /* a questions object */ },
-            { /* a questions object */ }
-          ]
-        }
+    **Format:** The request and response should match
+    :class:`.SampleQuestionSerializer`.
+    Requests should not include the ``questions`` key.
     """
 
     def post(self, request, format=None):
@@ -245,49 +159,11 @@ class DimensionDistributionView(APIView):
     In order to display helpful information for filtering, the distribution
     of a dimension may be queried using this API endpoint.
 
-    The request should include a dimension ``id`` and an optional ``query``
-    for very large dimensions that support filtering the distribution.
-
-    The response will include a ``domain`` property that is a list of values
-    for the dimension with a message count at each value.
-
     **Request:** ``POST /api/dimension``
 
-    **Example Request Body:**
-
-    ::
-
-        {
-          "dataset": 1,
-          "dimension": "time"
-        }
-
-    **Example Response:**
-
-    ::
-
-        {
-          "dataset": 2,
-          "dimension": 'time',
-          "distribution": [
-            {
-              "count": 5000,
-              "value": "some_time"
-            },
-            {
-              "count": 1000,
-              "value": "some_time"
-            },
-            {
-              "count": 500,
-              "value": "some_time"
-            },
-            {
-              "count": 50,
-              "value": "some_time"
-            }
-          ]
-        }
+    **Format:** The request and response should match
+    :class:`.DimensionDistributionSerializer`.
+    Requests should not include the ``messages`` key.
     """
 
     def post(self, request, format=None):

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -116,11 +116,11 @@ class ExampleMessagesView(APIView):
     Get some example messages matching the current filters and a focus
     within the visualization.
 
-    The request should include a list of dimension ids and active filters.
+    The request should include a list active filters.
     It should also include a ``focus`` object that specifies values for one
     or both of the given dimensions, keyed by name.
 
-    The response will be a list of `message objects <#messages>`_.
+    The response will include a list of `message objects <#messages>`_.
 
     **Request:** ``POST /api/messages``
 
@@ -129,7 +129,6 @@ class ExampleMessagesView(APIView):
     ::
 
         {
-          "dimensions": ["time", "hashtags"],
           "filters": [
             {
               "dimension": "time",

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -59,18 +59,14 @@ class DataTableView(APIView):
     ::
 
         {
-          "dimensions": [5, 8],
+          "dimensions": ['time', 'hashtags'],
           "filters": [
             {
-              "dimension": 5,
+              "dimension": 'time',
               "min": "2010-02-25T00:23:53Z",
               "max": "2010-02-30T00:23:53Z"
             }
           ],
-          "measure": {
-            "statistic": "message",
-            "aggregation": "count"
-          }
         }
 
     **Example Response Body:**
@@ -78,10 +74,10 @@ class DataTableView(APIView):
     ::
 
         {
-          "dimensions": [5, 8],
+          "dimensions": ['time', 'hashtags'],
           "filters": [
             {
-              "dimension": 5,
+              "dimension": 'time',
               "min": "2010-02-25T00:23:53Z",
               "max": "2010-02-30T00:23:53Z"
             }

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -192,7 +192,7 @@ class ResearchQuestionsView(APIView):
             data = input.validated_data
 
             dimension_list = data["dimensions"]
-            questions = questions_models.Question.get_sample_questions(dimension_list=dimension_list)
+            questions = questions_models.Question.get_sample_questions(*dimension_list)
 
             response_data = {
                 "dimensions": dimension_list,

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -152,6 +152,7 @@ class ExampleMessagesView(APIView):
     ::
 
         {
+          "dataset": 2,
           "filters": [
             {
               "dimension": "time",
@@ -173,7 +174,12 @@ class ExampleMessagesView(APIView):
         if input.is_valid():
             data = input.validated_data
 
-            example_messages = corpus_models.Dataset.get_example_messages(settings=data)
+            dataset = data['dataset']
+
+            filters = data['filters']
+            focus = data.get('focus', [])
+
+            example_messages = dataset.get_example_messages(filters + focus)
 
             # Just add the messages key to the response
             response_data = data

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -173,7 +173,7 @@ class ResearchQuestionsView(APIView):
     Get a list of research questions related to a selection of dimensions and filters.
     The request should include a list of :class:`.DimensionKey` ids and filter specifications.
 
-    The response will be a list of Research :class:`.Question`.
+    The response will include a list of Research :class:`.Question`.
 
     **Request:** ``POST /api/questions``
 
@@ -183,6 +183,18 @@ class ResearchQuestionsView(APIView):
 
         {
           "dimensions": ["hashtags", "time"]
+        }
+
+    **Example Response:**
+
+    ::
+
+        {
+          "dimensions": ["hashtags", "time"]
+          "questions" [
+            { /* a questions object */ },
+            { /* a questions object */ }
+          ]
         }
     """
 

--- a/msgvis/apps/corpus/models.py
+++ b/msgvis/apps/corpus/models.py
@@ -16,22 +16,18 @@ class Dataset(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def get_example_messages(cls, settings):
-        """Get example messages with filter and focus settings"""
+    def get_example_messages(self, filters):
+        """Get example messages given some filters (dictionaries containing dimensions and filter params)"""
 
-        from msgvis.apps.dimensions.registry import get_dimension
+        messages = self.message_set.all()
 
-        # TODO: convert this into a regular method so that we can easily filter on a dataset
-        # e.g. messages = self.message_set.all()
-        messages = Message.objects.all()
-        if settings.get("filters"):
-            for filter in settings["filters"]:
-                messages = get_dimension(filter["dimension"]).filter(messages, filter)
+        for filter in filters:
+            dimension = filter["dimension"]
 
-        if settings.get("focus"):
-            for focus in settings["focus"]:
-                messages = get_dimension(focus["dimension"]).filter(messages, focus)
+            # Remove the dimension key
+            params = {key: value for key, value in filter.iteritems() if key != "dimension"}
+
+            messages = dimension.filter(messages, **params)
 
         return messages[:10]
 

--- a/msgvis/apps/corpus/tests.py
+++ b/msgvis/apps/corpus/tests.py
@@ -4,7 +4,7 @@ from unittest import skip
 from django.test import TestCase
 
 from msgvis.apps.corpus import models as corpus_models
-
+from msgvis.apps.dimensions import registry
 
 class DatasetModelTest(TestCase):
     def test_created_at_set(self):
@@ -28,21 +28,26 @@ class MessageModelTest(TestCase):
 
 
 class GetExampleMessageTest(TestCase):
-
     def generate_some_messages(self, dataset):
         corpus_models.Message.objects.create(
             dataset=dataset,
             text="blah blah blah",
             time="2015-02-02T01:19:02Z",
-            )
+            shared_count=0,
+        )
 
         hashtag = corpus_models.Hashtag.objects.create(text="OurPriorities")
         msg = corpus_models.Message.objects.create(
             dataset=dataset,
             text="blah blah blah #%s" % hashtag.text,
-            time="2015-02-02T01:19:02Z"
+            time="2015-02-02T01:19:02Z",
+            shared_count=10,
         )
         msg.hashtags.add(hashtag)
+
+        self.dimension_time = registry.get_dimension('time')
+        self.dimension_hashtags = registry.get_dimension('hashtags')
+        self.dimension_shared = registry.get_dimension('shares')
 
     def setUp(self):
         self.dataset = corpus_models.Dataset.objects.create(name="Test Corpus", description="My Dataset")
@@ -51,82 +56,73 @@ class GetExampleMessageTest(TestCase):
 
     def test_with_no_filters(self):
         """Empty filter settings should return all messages"""
-        settings = {}
-        msgs = self.dataset.get_example_messages(settings=settings)
+        filters = {}
+        msgs = self.dataset.get_example_messages(filters)
         self.assertEquals(msgs.count(), 2)
 
     def test_with_inclusive_filters(self):
         """Filters that include all the messages."""
-        settings = {
-            "dimensions": ["time", "hashtags"],
-            "filters": [
-                {
-                    "dimension": "time",
-                    "min": "2015-02-02T01:19:02Z",
-                    "max": "2015-02-02T01:19:03Z"
-                }
-            ],
-            "focus": [
-                {
-                    "dimension": "time",
-                    "value": "2015-02-02T01:19:02Z",
-                }
-            ],
-        }
+        filters = [
+            {
+                "dimension": self.dimension_time,
+                "min_time": "2015-02-02T01:19:02Z",
+                "max_time": "2015-02-02T01:19:03Z"
+            },
+            {
+                "dimension": self.dimension_time,
+                "value": "2015-02-02T01:19:02Z",
+            }
+        ]
 
-        msgs = self.dataset.get_example_messages(settings=settings)
+        msgs = self.dataset.get_example_messages(filters)
         self.assertEquals(msgs.count(), 2)
 
     def test_with_exclusive_filters(self):
         """Filters that exclude all the messages"""
-        settings = {
-            "dimensions": ["time", "hashtags"],
-            "filters": [
-                {
-                    "dimension": "time",
-                    "min": "2015-02-02T01:19:03Z",
-                    "max": "2015-02-02T01:19:03Z"
-                }
-            ],
-            "focus": [
-                {
-                    "dimension": "time",
-                    "value": "2015-02-02T01:19:03Z",
-                }
-            ],
-        }
-        msgs = self.dataset.get_example_messages(settings=settings)
+        filters = [
+            {
+                "dimension": self.dimension_time,
+                "min_time": "2015-02-02T01:19:03Z",
+                "max_time": "2015-02-02T01:19:03Z"
+            },
+            {
+                "dimension": self.dimension_time,
+                "value": "2015-02-02T01:19:03Z",
+            }
+        ]
+        msgs = self.dataset.get_example_messages(filters)
         self.assertEquals(msgs.count(), 0)
 
-    def test_partial_match(self):
-        """Filters that match just one message"""
-
-        settings = {
-            "dimensions": ["time", "hashtags"],
-            "filters": [
-                {
-                    "dimension": "time",
-                    "min": "2015-02-02T01:19:03Z",
-                    "max": "2015-02-02T01:19:03Z"
-                }
-            ],
-            "focus": [
-                {
-                    "dimension": "hashtags",
-                    "value": "OurPriorities",
-                }
-            ],
-        }
-        msgs = self.dataset.get_example_messages(settings=settings)
+    def test_quantitative_filter(self):
+        """Filter on a numeric field"""
+        filters = [
+            {
+                "dimension": self.dimension_shared,
+                "min": 5,
+                "max": 15,
+            },
+        ]
+        msgs = self.dataset.get_example_messages(filters)
         self.assertEquals(msgs.count(), 1)
 
-    @skip("get_example_messages is not yet an instance method")
+    def test_value_match(self):
+        """Filters that match just one message"""
+
+        filters = [
+            {
+                "dimension": self.dimension_hashtags,
+                "value": "OurPriorities",
+            }
+        ]
+        msgs = self.dataset.get_example_messages(filters)
+        self.assertEquals(msgs.count(), 1)
+
     def test_dataset_specific_examples(self):
         """Does not mix messages across datasets."""
 
         other_dataset = corpus_models.Dataset.objects.create(name="second test corpus", description="blah")
         self.generate_some_messages(other_dataset)
 
-        settings = {}
-        msgs = self.dataset.get_example_messages(settings=settings)
+        filters = {}
+        msgs = self.dataset.get_example_messages(filters)
         self.assertEquals(msgs.count(), 2)

--- a/msgvis/apps/questions/models.py
+++ b/msgvis/apps/questions/models.py
@@ -54,7 +54,7 @@ class Question(models.Model):
         return self.text
 
     @classmethod
-    def get_sample_questions(cls, dimension_list):
+    def get_sample_questions(cls, *dimension_list):
         """
         Given dimensions, return sample research questions.
         """

--- a/msgvis/apps/questions/tests.py
+++ b/msgvis/apps/questions/tests.py
@@ -21,20 +21,19 @@ class GetSampleQuestionTest(TestCase):
         question.add_dimension("language")
         question.save()
 
-    def test_get_sample_question(self):
-
-        dimension_list = []
-        questions = Question.get_sample_questions(dimension_list=dimension_list)
+    def test_no_dimensions(self):
+        """When you don't request any dimensions it returns all the questions"""
+        questions = Question.get_sample_questions()
         self.assertEquals(questions.count(), 3)
-
-        dimension_list = ["hashtags"]
-        questions = Question.get_sample_questions(dimension_list=dimension_list)
+    def test_one_dimension(self):
+        """With a dimension that matches one question"""
+        questions = Question.get_sample_questions('hashtags')
         self.assertEquals(questions.count(), 1)
-
-        dimension_list = ["language"]
-        questions = Question.get_sample_questions(dimension_list=dimension_list)
+    def test_one_dimension_multi_match(self):
+        """Try matching a dimension with multiple questions"""
+        questions = Question.get_sample_questions('language')
         self.assertEquals(questions.count(), 2)
-
-        dimension_list = ["language", "urls"]
-        questions = Question.get_sample_questions(dimension_list=dimension_list)
+    def test_multiple_dimensions(self):
+        """Match against multiple dimensions"""
+        questions = Question.get_sample_questions('language', 'urls')
         self.assertEquals(questions.count(), 1)


### PR DESCRIPTION
Implemented the API view and serializer for data tables.
Also changed some of the api for example messages for #39.
Slightly changed the way `get_example_message()` works, and the `FilterSerializer`.