### PR TITLE
Add d3 charts of distributions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "angular-route": "~1.3.13",
     "angular-cookies": "~1.3.13",
     "angular-dragdrop": "~1.0.11",
-    "angular-animate": "~1.3.13"
+    "angular-animate": "~1.3.13",
+    "d3": "~3.5.5"
   }
 }

--- a/msgvis/static/SparQs/SparQs.js
+++ b/msgvis/static/SparQs/SparQs.js
@@ -4,10 +4,13 @@
 (function () {
     'use strict';
 
+    angular.module('SparQs.bootstrap', []);
+
     // Declare app level module which depends on other modules
     var app = angular
         .module('SparQs', [
             'SparQs.controllers',
+            'SparQs.charts',
             'ngCookies',
             'ngDragDrop',
             'ngAnimate'

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -1,0 +1,117 @@
+(function () {
+    'use strict';
+
+
+    var module = angular.module('SparQs.charts', []);
+
+    module.directive('quantHistogram', function ($parse) {
+
+        function link(scope, $element, attrs) {
+
+            var yProp = attrs.chartY || 'y';
+            var xProp = attrs.chartX || 'x';
+
+            var xScale = d3.scale.ordinal();
+            var yScale = d3.scale.linear();
+
+            var getX = function(d) {
+                return d[xProp];
+            };
+
+            var getY = function(d) {
+                return d[yProp];
+            };
+
+            var $d3_element = d3.select($element[0]);
+            var svg = $d3_element.append("svg");
+
+            var margin = {
+                top: 3,
+                right: 3,
+                bottom: 3,
+                left: 3
+            };
+
+            var chart = svg
+                .append('g')
+                .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            var elementSize = function () {
+                console.log("visible: " + $element.is(':visible'));
+                return {
+                    width: $element.innerWidth(),
+                    height: $element.innerHeight()
+                }
+            };
+
+            // Watch for size changes
+            //scope.$watch(elementSize, function () {
+            //    scope.render();
+            //}, true);
+
+            // Watch for visibility changes
+            scope.$watch('visible', function(newVals, oldVals) {
+                if (newVals) return scope.render();
+            }, false);
+
+            // Watch for data changes (just reference, not object equals)
+            scope.$watch('distribution', function(newVals, oldVals) {
+                return scope.render();
+            }, false);
+
+            scope.render = function () {
+                var size = elementSize();
+
+                console.log('Full size', size);
+                var graphWidth = size.width - margin.right - margin.left;
+                var graphHeight = size.height - margin.top - margin.bottom;
+                console.log('rendering to ' + graphWidth + ' x ' + graphHeight);
+
+                var data = scope.distribution || [];
+
+                var yExtent = d3.extent(data, getY);
+                yScale
+                    .domain([0, yExtent[1]])
+                    .range([0, graphHeight]);
+
+                xScale
+                    .domain(data.map(getX))
+                    .rangeRoundBands([0, graphWidth], 0.1, 0.1);
+
+                var bind = chart.selectAll('rect.bar')
+                    .data(data);
+
+                bind.exit()
+                    .remove();
+
+                bind.enter()
+                    .append("rect")
+                    .attr('class', 'bar')
+                    .attr('height', 0)
+                    .attr('x', function(d) {
+                        return xScale(d[xProp]);
+                    })
+                    .attr('y', function(d) {
+                        return graphHeight - yScale(d[yProp]);
+                    })
+                    .attr('width', xScale.rangeBand())
+                    .attr("height", function(d) {
+                        return yScale(d[yProp]);
+                    });
+            };
+        }
+
+        return {
+            //Use as a tag only
+            restrict: 'E',
+            replace: false,
+
+            //Directive's inner scope
+            scope: {
+                distribution: '=distribution',
+                visible: '=visible'
+            },
+            link: link
+        };
+    });
+})();

--- a/msgvis/static/SparQs/controllers.js
+++ b/msgvis/static/SparQs/controllers.js
@@ -6,11 +6,6 @@
         'SparQs.services'
     ]);
 
-    //Hard coded dataset id for now
-    module.constant('SparQs.bootstrap', {
-        dataset: 1
-    });
-
     module.config(function ($interpolateProvider) {
         $interpolateProvider.startSymbol('{$');
         $interpolateProvider.endSymbol('$}');
@@ -87,7 +82,17 @@
             Selection.changed('dimensions');
         };
 
-        $scope.filtering = Filtering
+        $scope.openFilter = function(dimension, $event) {
+            var offset;
+            if ($event) {
+                var $el = $($event.target).parents('.dimension');
+                if ($el) {
+                    offset = $el.offset();
+                }
+            }
+
+            Filtering.toggle(dimension, offset);
+        }
     };
 
     DimensionController.$inject = [
@@ -99,34 +104,24 @@
     module.controller('SparQs.controllers.DimensionController', DimensionController);
 
 
-    var ExampleMessageController = function ($scope, ExampleMessages, Selection, bootstrap) {
-
-        var dataset = bootstrap.dataset;
+    var ExampleMessageController = function ($scope, ExampleMessages, Selection, Dataset) {
 
         $scope.messages = ExampleMessages;
 
         $scope.get_example_messages = function () {
             var filters = Selection.filters();
             var focus = Selection.focus();
-            ExampleMessages.load(dataset, filters, focus);
+            ExampleMessages.load(Dataset.id, filters, focus);
         };
 
         Selection.changed('filters,focus', $scope, $scope.get_example_messages);
-        /*
-         $scope.$watch('selection.filters()', function() {
-         $scope.get_example_messages();
-         }, true);
 
-         $scope.$watch('selection.focus()', function() {
-         $scope.get_example_messages();
-         }, true);
-         */
     };
     ExampleMessageController.$inject = [
         '$scope',
         'SparQs.services.ExampleMessages',
         'SparQs.services.Selection',
-        'SparQs.bootstrap'
+        'SparQs.services.Dataset'
     ];
     module.controller('SparQs.controllers.ExampleMessageController', ExampleMessageController);
 
@@ -155,9 +150,7 @@
     ];
     module.controller('SparQs.controllers.SampleQuestionController', SampleQuestionController);
 
-    var VisualizationController = function ($scope, Selection, DataTables, bootstrap) {
-
-        var dataset = bootstrap.dataset;
+    var VisualizationController = function ($scope, Selection, DataTables, Dataset) {
 
         $scope.datatable = DataTables;
         $scope.selection = Selection;
@@ -165,27 +158,20 @@
         $scope.get_data_table = function () {
             var dimensions = Selection.dimensions();
             var filters = Selection.filters();
-            DataTables.load(dataset, dimensions, filters);
+            DataTables.load(Dataset.id, dimensions, filters);
         };
 
         $scope.get_data_table();
 
         Selection.changed('dimensions,filters', $scope, $scope.get_data_table);
 
-        //$scope.$watch('selection.dimensions()', function() {
-        //    $scope.get_data_table();
-        //}, true);
-        //
-        //$scope.$watch('selection.filters()', function() {
-        //    $scope.get_data_table();
-        //}, true);
     };
 
     VisualizationController.$inject = [
         '$scope',
         'SparQs.services.Selection',
         'SparQs.services.DataTables',
-        'SparQs.bootstrap'
+        'SparQs.services.Dataset'
     ];
     module.controller('SparQs.controllers.VisualizationController', VisualizationController);
 
@@ -193,16 +179,20 @@
     var FilterController = function ($scope, Filtering, Selection) {
         $scope.filtering = Filtering;
 
-        $scope.saveFilter = function() {
+        $scope.closeFilter = function() {
+            Filtering.toggle();
+        };
+
+        $scope.saveFilter = function () {
             if ($scope.filtering.dimension.filter.dirty) {
                 Selection.changed('filters');
                 $scope.filtering.dimension.filter.saved();
             }
         };
 
-        $scope.resetFilter = function() {
+        $scope.resetFilter = function () {
             if (!$scope.filtering.dimension.filter.is_empty()) {
-                $scope.filtering.dimension.filter.reset()
+                $scope.filtering.dimension.filter.reset();
                 Selection.changed('filters');
                 $scope.filtering.dimension.filter.saved();
             }

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -9,7 +9,8 @@
     //The collection of dimensions.
     //Dimension objects have some extra functionality added.
     module.factory('SparQs.services.Dimensions', [
-        function () {
+        'SparQs.services.DimensionDistributions',
+        function (DimensionDistributions) {
 
             var filterProps = [
                 'min',
@@ -102,6 +103,7 @@
                 this.filter = new Filter(this.filter);
                 this.filtering = false; //true if currently being filtered
                 this.description = [this.name, this.name, this.name].join(', ') + '!';
+                this.distribution = undefined;
             };
 
             angular.extend(Dimension.prototype, {
@@ -125,8 +127,27 @@
                 },
                 serialize_filter: function () {
                     return angular.extend({
-                        dimension: this.key,
+                        dimension: this.key
                     }, this.filter.data);
+                },
+                set_filtering: function(filtering) {
+                    if (this.filtering != filtering) {
+                        this.filtering = filtering;
+
+                        if (filtering) {
+                            this.load_distribution()
+                        }
+                    }
+                },
+                load_distribution: function (dataset) {
+                    if (!this._loading && !this.distribution) {
+                        this._loading = true;
+                        DimensionDistributions.load(this);
+                    }
+                },
+                set_distribution: function(distribution) {
+                    this._loading = false;
+                    this.distribution = distribution;
                 }
             });
 

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -373,6 +373,8 @@ body {
 }
 
 @filter-popup-width: 250px;
+@filter-body-width: @filter-popup-width - 2;
+@filter-histogram-width: @filter-body-width - 16;
 #filter-popup {
     position: absolute;
     left: @left-col-width + 1px;
@@ -406,7 +408,7 @@ body {
 
     .filter-body {
         padding: 8px;
-        width: @filter-popup-width - 2;
+        width: @filter-body-width;
     }
 
     .transition(linear 0.3s);
@@ -451,5 +453,23 @@ body {
         width: 60px;
         margin: 5px;
         padding: 4px 10px;
+    }
+}
+
+quant-histogram {
+    width: @filter-histogram-width;
+    height: 75px;
+    position: relative;
+    display: block;
+
+    > svg {
+        width: 100%;
+        height: 100%;
+
+        font: 10px sans-serif;
+    }
+
+    rect.bar {
+        fill: steelblue;
     }
 }

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -25,10 +25,13 @@
 
 <script src="{% static 'djangular/js/django-angular.js' %}"></script>
 
+<script src="{% static 'bower/d3/d3.js' %}"></script>
+
 <script src="{% static 'SparQs/SparQs.js' %}"></script>
 <script src="{% static 'SparQs/controllers.js' %}"></script>
 <script src="{% static 'SparQs/services.js' %}"></script>
 <script src="{% static 'SparQs/services/dimensions_service.js' %}"></script>
+<script src="{% static 'SparQs/charts.js' %}"></script>
 {% endblock %}
 
 {% block navigation_bar %}
@@ -39,6 +42,9 @@
 <script>
     angular.module('ng.django.urls')
         .constant('patterns', {% load_djng_urls %});
+
+    angular.module('SparQs.bootstrap')
+        .constant('SparQs.bootstrap.dataset', 1);
 
     angular.module('SparQs.services')
         .constant('token_images', {
@@ -95,7 +101,7 @@
                                     <span class="dimension-name" ng-bind="dimension.name"></span>
 
                                     <div class="dimension-filter"
-                                         ng-click="filtering.toggleFilter(dimension, $event)"></div>
+                                         ng-click="openFilter(dimension, $event)"></div>
                                 </div>
                             </div>
                         </div>
@@ -158,14 +164,14 @@
     </div>
     <div id="filter-popup"
          class="ng-cloak" ng-cloak
-         ng-show="filtering.dimension"
+         ng-show="filtering.dimension.filtering"
          ng-controller="SparQs.controllers.FilterController"
          ng-style="{top:filtering.offset.top}">
         <div ng-class="'filter-' + dimension.type">
             <h3>
                 Filter on {$ filtering.dimension.name $}
                 <button type="button" class="close"
-                    ng-click="filtering.toggleFilter()">
+                    ng-click="closeFilter()">
                     <span>&times;</span>
                 </button>
             </h3>
@@ -173,6 +179,13 @@
                 <form ng-submit="saveFilter()">
                     <p class="description">{$ filtering.dimension.description $}</p>
                     <p class="form-group" ng-show="filtering.dimension.is_quantitative()">
+
+                        <quant-histogram
+                            visible="filtering.dimension.filtering"
+                            distribution="filtering.dimension.distribution"
+                            chart-x="value" chart-y="count">
+                        </quant-histogram>
+
                         <input type="text" class="filter-min form-control"
                                ng-model="filtering.dimension.filter.min"
                                ng-model-options="{ getterSetter: true }"


### PR DESCRIPTION
Includes a quant-histogram directive for rendering d3 charts of distributions.
This only works for quantitative dimensions. It also does not really show the distribution well because the x-axis is interpreted as ordinal and since the server provides data with missing entries for 0-valued bins, the results are bad.

We also still need to add brushing and labels.