### PR TITLE
Empty quant data tables

### DIFF
--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -76,6 +76,10 @@ class DataTable(object):
             secondary_group = self.secondary_dimension.get_grouping_expression(queryset,
                                                                                bins=desired_secondary_bins)
 
+            if primary_group is None or secondary_group is None:
+                # There is no data to group
+                return queryset.values()
+
             queryset, internal_primary_key = self.primary_dimension.select_grouping_expression(
                 queryset,
                 primary_group)

--- a/msgvis/apps/datatable/tests.py
+++ b/msgvis/apps/datatable/tests.py
@@ -375,6 +375,32 @@ class QuantitativeDistributionsTest(DistributionTestCaseMixins, TestCase):
         self.doQuantitativeDimensionsTest('shares', dataset, binned_distribution, desired_primary_bins=5)
 
 
+
+    def test_excludes_all_data(self):
+        """
+        If the filters exclude all the data, an empty result set should be produced.
+        """
+
+        field_names = ('shared_count', 'replied_to_count')
+        values = [(1, 1), (1, 4), (1, 3), (2, 1), (2, 2)]
+        bi_distribution = self.get_distribution(values)
+
+        dataset = self.generate_messages_for_multi_distribution(field_names, bi_distribution)
+
+        d1 = registry.get_dimension('shares')
+        d2 = registry.get_dimension('replies')
+
+        datatable = models.DataTable(d1, d2)
+
+        filtered = dataset.message_set.filter(
+            shared_count__range=(2, 5),
+            replied_to_count__range=(3, 5),
+        )
+
+        result = datatable.render(filtered)
+        self.assertEquals(result.count(), 0)
+
+
 class TimeDistributionsTest(DistributionTestCaseMixins, TestCase):
     def setUp(self):
         # Get an arbitrary time to work with

--- a/msgvis/apps/dimensions/models.py
+++ b/msgvis/apps/dimensions/models.py
@@ -334,6 +334,10 @@ class QuantitativeDimension(CategoricalDimension):
 
         expression = self.get_grouping_expression(queryset, bins=bins, bin_size=bin_size, **kwargs)
 
+        if expression is None:
+            # no results
+            return queryset.values()
+
         if expression == self.field_name:
 
             # We still have to map back to the requested grouping_key


### PR DESCRIPTION
Fix for #53.

When there is no range, quant dimensions have no grouping expression.
When there is no grouping expression, quant dimensions cannot group by, and return empty sets.
Similarly, for data tables, when either of the two dimensions have no grouping expressions, it must return an empty table.