### PR TITLE
Use many-to-many relationship for topics, test topic modeling

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -34,6 +34,7 @@ def dependencies(default_env='dev'):
     pip_install(default_env)
     npm_install()
     bower_install()
+    nltk_init()
 
 test = factories.test_task(default_settings='msgvis.settings.test')
 test_coverage = factories.coverage_task(default_settings='msgvis.settings.test')

--- a/msgvis/apps/enhance/management/commands/extract_topics.py
+++ b/msgvis/apps/enhance/management/commands/extract_topics.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         except ValueError:
             raise CommandError("Dataset id must be a number.")
 
-        from msgvis.apps.enhance.tasks import get_message_context,data_pipeline
+        from msgvis.apps.enhance.tasks import default_topic_context, standard_topic_pipeline
 
-        context = get_message_context(name, dataset_id=dataset_id)
-        data_pipeline(context, num_topics=int(num_topics))
+        context = default_topic_context(name, dataset_id=dataset_id)
+        standard_topic_pipeline(context, num_topics=int(num_topics))

--- a/msgvis/apps/enhance/migrations/0002_auto_20150303_2223.py
+++ b/msgvis/apps/enhance/migrations/0002_auto_20150303_2223.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enhance', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='messagetopic',
+            name='source',
+            field=models.ForeignKey(to='corpus.Message'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messagetopic',
+            name='topic_model',
+            field=models.ForeignKey(to='enhance.TopicModel'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messageword',
+            name='dictionary',
+            field=models.ForeignKey(to='enhance.Dictionary'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messageword',
+            name='source',
+            field=models.ForeignKey(to='corpus.Message'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='topicword',
+            name='topic',
+            field=models.ForeignKey(to='enhance.Topic'),
+            preserve_default=True,
+        ),
+        migrations.AlterIndexTogether(
+            name='messagetopic',
+            index_together=set([]),
+        ),
+        migrations.AlterIndexTogether(
+            name='messageword',
+            index_together=set([]),
+        ),
+    ]

--- a/msgvis/apps/enhance/migrations/0003_auto_20150303_2224.py
+++ b/msgvis/apps/enhance/migrations/0003_auto_20150303_2224.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enhance', '0002_auto_20150303_2223'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='messagetopic',
+            old_name='source',
+            new_name='message',
+        ),
+        migrations.RenameField(
+            model_name='messageword',
+            old_name='source',
+            new_name='message',
+        ),
+        migrations.AlterField(
+            model_name='messagetopic',
+            name='topic_model',
+            field=models.ForeignKey(to='enhance.TopicModel', db_index=False),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messageword',
+            name='dictionary',
+            field=models.ForeignKey(to='enhance.Dictionary', db_index=False),
+            preserve_default=True,
+        ),
+        migrations.AlterIndexTogether(
+            name='messagetopic',
+            index_together=set([('topic_model', 'message')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='messageword',
+            index_together=set([('dictionary', 'message')]),
+        ),
+    ]

--- a/msgvis/apps/enhance/migrations/0004_auto_20150303_2225.py
+++ b/msgvis/apps/enhance/migrations/0004_auto_20150303_2225.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('corpus', '0015_auto_20150303_0343'),
+        ('enhance', '0003_auto_20150303_2224'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topic',
+            name='messages',
+            field=models.ManyToManyField(related_name='topics', through='enhance.MessageTopic', to='corpus.Message'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='topic',
+            name='words',
+            field=models.ManyToManyField(related_name='topics', through='enhance.TopicWord', to='enhance.Word'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='word',
+            name='messages',
+            field=models.ManyToManyField(related_name='words', through='enhance.MessageWord', to='corpus.Message'),
+            preserve_default=True,
+        ),
+    ]

--- a/msgvis/apps/enhance/migrations/0005_auto_20150303_2230.py
+++ b/msgvis/apps/enhance/migrations/0005_auto_20150303_2230.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enhance', '0004_auto_20150303_2225'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='messagetopic',
+            name='message',
+            field=models.ForeignKey(related_name='topic_probabilities', to='corpus.Message'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messagetopic',
+            name='topic',
+            field=models.ForeignKey(related_name='message_probabilities', to='enhance.Topic'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messageword',
+            name='message',
+            field=models.ForeignKey(related_name='word_scores', to='corpus.Message'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='messageword',
+            name='word',
+            field=models.ForeignKey(related_name='message_scores', to='enhance.Word'),
+            preserve_default=True,
+        ),
+    ]

--- a/msgvis/apps/enhance/models.py
+++ b/msgvis/apps/enhance/models.py
@@ -16,6 +16,7 @@ import logging
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
+
 class Dictionary(models.Model):
     name = models.CharField(max_length=100)
     dataset = models.CharField(max_length=100)
@@ -130,7 +131,7 @@ class Dictionary(models.Model):
 
         return dict_model
 
-    def _vectorize_corpus(self, queryset, tokenizer, wv_class, textfield='text'):
+    def _vectorize_corpus(self, queryset, tokenizer):
 
         import math
 
@@ -144,24 +145,24 @@ class Dictionary(models.Model):
         batch_size = 1000
         print_freq = 10000
 
-        for obj in queryset.iterator():
-            text = getattr(obj, textfield)
+        for msg in queryset.iterator():
+            text = msg.text
             bow = gdict.doc2bow(tokenizer.tokenize(text))
 
             for word_index, word_freq in bow:
                 word_id = self.get_word_id(word_index)
                 document_freq = gdict.dfs[word_index]
                 tfidf = word_freq * math.log(total_documents, document_freq)
-                batch.append(wv_class.create(dictionary=self,
-                                             word_id=word_id,
-                                             word_index=word_index,
-                                             count=word_freq,
-                                             tfidf=tfidf,
-                                             source_obj=obj))
+                batch.append(MessageWord(dictionary=self,
+                                         word_id=word_id,
+                                         word_index=word_index,
+                                         count=word_freq,
+                                         tfidf=tfidf,
+                                         message=msg))
             count += 1
 
             if len(batch) > batch_size:
-                wv_class.objects.bulk_create(batch)
+                MessageWord.objects.bulk_create(batch)
                 batch = []
 
                 if settings.DEBUG:
@@ -174,7 +175,7 @@ class Dictionary(models.Model):
                 logger.info("Saved word-vectors for %d / %d documents" % (count, total_count))
 
         if len(batch):
-            wv_class.objects.bulk_create(batch)
+            MessageWord.objects.bulk_create(batch)
             logger.info("Saved word-vectors for %d / %d documents" % (count, total_count))
 
         logger.info("Created %d word vector entries" % count)
@@ -222,7 +223,7 @@ class Dictionary(models.Model):
 
         return (model, lda)
 
-    def _apply_lda(self, model, corpus, topicvector_class, lda=None):
+    def _apply_lda(self, model, corpus, lda=None):
 
         if lda is None:
             # recover the lda
@@ -239,20 +240,20 @@ class Dictionary(models.Model):
         # Go through the bows and get their topic mixtures
         for bow in corpus:
             mixture = lda[bow]
-            source_id = corpus.current_source_id
+            message_id = corpus.current_message_id
 
             for topic_index, prob in mixture:
                 topic = topics[topic_index]
-                itemtopic = topicvector_class(topic_model=model,
-                                              topic=topic,
-                                              probability=prob,
-                                              source_id=source_id)
+                itemtopic = MessageTopic(topic_model=model,
+                                         topic=topic,
+                                         message_id=message_id,
+                                         probability=prob)
                 batch.append(itemtopic)
 
             count += 1
 
             if len(batch) > batch_size:
-                topicvector_class.objects.bulk_create(batch)
+                MessageTopic.objects.bulk_create(batch)
                 batch = []
 
                 if settings.DEBUG:
@@ -265,7 +266,7 @@ class Dictionary(models.Model):
                 logger.info("Saved topic-vectors for %d / %d documents" % (count, total_documents))
 
         if len(batch):
-            topicvector_class.objects.bulk_create(batch)
+            MessageTopic.objects.bulk_create(batch)
             logger.info("Saved topic-vectors for %d / %d documents" % (count, total_documents))
 
     def _evaluate_lda(self, model, corpus, lda=None):
@@ -279,17 +280,22 @@ class Dictionary(models.Model):
         logger.info("Perplexity: %f" % model.perplexity)
         model.save()
 
+
 class Word(models.Model):
     dictionary = models.ForeignKey(Dictionary, related_name='words')
     index = models.IntegerField()
     text = models.CharField(max_length=100)
     document_frequency = models.IntegerField()
 
+    messages = models.ManyToManyField(Message, through='MessageWord', related_name='words')
+
 
 class TopicModel(models.Model):
     dictionary = models.ForeignKey(Dictionary)
+
     name = models.CharField(max_length=100)
     description = models.CharField(max_length=200)
+
     time = models.DateTimeField(auto_now_add=True)
     perplexity = models.FloatField(default=0)
 
@@ -309,41 +315,43 @@ class Topic(models.Model):
     index = models.IntegerField()
     alpha = models.FloatField()
 
+    messages = models.ManyToManyField(Message, through='MessageTopic', related_name='topics')
+    words = models.ManyToManyField(Word, through='TopicWord', related_name='topics')
+
 
 class TopicWord(models.Model):
     word = models.ForeignKey(Word)
+    topic = models.ForeignKey(Topic)
+
     word_index = models.IntegerField()
     probability = models.FloatField()
-    topic = models.ForeignKey(Topic, related_name='words')
 
 
-class AbstractWordVector(models.Model):
+class MessageWord(models.Model):
     class Meta:
-        abstract = True
-        index_together = ['dictionary', 'source']
+        index_together = ['dictionary', 'message']
 
     dictionary = models.ForeignKey(Dictionary, db_index=False)
-    word = models.ForeignKey(Word)
+
+    word = models.ForeignKey(Word, related_name="message_scores")
+    message = models.ForeignKey(Message, related_name='word_scores')
+
     word_index = models.IntegerField()
     count = models.FloatField()
     tfidf = models.FloatField()
 
-    @classmethod
-    def create(cls, dictionary, word_id, word_index, source_obj, count, tfidf):
-        return cls(dictionary=dictionary,
-                   word_id=word_id, word_index=word_index,
-                   count=count, tfidf=tfidf,
-                   source=source_obj)
 
-
-class AbstractTopicVector(models.Model):
+class MessageTopic(models.Model):
     class Meta:
-        abstract = True
-        index_together = ['topic_model', 'source']
+        index_together = ['topic_model', 'message']
 
     topic_model = models.ForeignKey(TopicModel, db_index=False)
-    topic = models.ForeignKey(Topic)
+
+    topic = models.ForeignKey(Topic, related_name='message_probabilities')
+    message = models.ForeignKey(Message, related_name="topic_probabilities")
+
     probability = models.FloatField()
+
 
     @classmethod
     def get_examples(cls, topic):
@@ -351,15 +359,6 @@ class AbstractTopicVector(models.Model):
         return examples.order_by('-probability')
 
 
-class MessageWord(AbstractWordVector):
-    source = models.ForeignKey(Message, related_name='words')
-
-
-class MessageTopic(AbstractTopicVector):
-    source = models.ForeignKey(Message, related_name='topics')
-
-
 def set_message_sentiment(message):
-
     message.sentiment = int(round(textblob.TextBlob(message.text).sentiment.polarity))
     message.save()

--- a/msgvis/apps/enhance/tasks.py
+++ b/msgvis/apps/enhance/tasks.py
@@ -175,9 +175,9 @@ class TopicContext(object):
         dictionary._vectorize_corpus(queryset=self.queryset,
                                      tokenizer=tokenized_texts)
 
-    def build_lda(self, dictionary, num_topics=30):
+    def build_lda(self, dictionary, num_topics=30, **kwargs):
         corpus = DbWordVectorIterator(dictionary)
-        return dictionary._build_lda(self.name, corpus, num_topics=num_topics)
+        return dictionary._build_lda(self.name, corpus, num_topics=num_topics, **kwargs)
 
     def apply_lda(self, dictionary, model, lda=None):
         corpus = DbWordVectorIterator(dictionary)
@@ -188,7 +188,7 @@ class TopicContext(object):
         return dictionary._evaluate_lda(model, corpus, lda=lda)
 
 
-def standard_topic_pipeline(context, num_topics):
+def standard_topic_pipeline(context, num_topics, **kwargs):
     dictionary = context.find_dictionary()
     if dictionary is None:
         dictionary = context.build_dictionary()
@@ -196,7 +196,7 @@ def standard_topic_pipeline(context, num_topics):
     if not context.bows_exist(dictionary):
         context.build_bows(dictionary)
 
-    model, lda = context.build_lda(dictionary, num_topics=num_topics)
+    model, lda = context.build_lda(dictionary, num_topics=num_topics, **kwargs)
     context.apply_lda(dictionary, model, lda)
     context.evaluate_lda(dictionary, model, lda)
 

--- a/msgvis/apps/enhance/tasks.py
+++ b/msgvis/apps/enhance/tasks.py
@@ -21,49 +21,47 @@ def get_stoplist():
 
 
 class DbTextIterator(object):
-    def __init__(self, queryset, textfield='text'):
+    def __init__(self, queryset):
         self.queryset = queryset
-        self.textfield = textfield
         self.current_position = 0
         self.current = None
 
     def __iter__(self):
         self.current_position = 0
-        for obj in self.queryset.iterator():
-            self.current = obj
+        for msg in self.queryset.iterator():
+            self.current = msg
             self.current_position += 1
             if self.current_position % 10000 == 0:
                 logger.info("Iterating through database texts: item %d" % self.current_position)
 
-            yield getattr(obj, self.textfield)
+            yield msg.text
 
 
 class DbWordVectorIterator(object):
-    def __init__(self, dictionary, wv_class, freq_field='tfidf'):
+    def __init__(self, dictionary, freq_field='tfidf'):
         self.dictionary = dictionary
-        self.wv_class = wv_class
         self.freq_field = freq_field
-        self.current_source_id = None
+        self.current_message_id = None
         self.current_vector = None
 
     def __iter__(self):
-        qset = self.wv_class.objects.filter(dictionary=self.dictionary).order_by('source')
-        self.current_source_id = None
+        qset = MessageWord.objects.filter(dictionary=self.dictionary).order_by('message')
+        self.current_message_id = None
         self.current_vector = []
         current_position = 0
-        for wv in qset.iterator():
-            source_id = wv.source_id
-            word_idx = wv.word_index
-            freq = getattr(wv, self.freq_field)
+        for mw in qset.iterator():
+            message_id = mw.message_id
+            word_idx = mw.word_index
+            freq = getattr(mw, self.freq_field)
 
-            if self.current_source_id is None:
-                self.current_source_id = source_id
+            if self.current_message_id is None:
+                self.current_message_id = message_id
                 self.current_vector = []
 
-            if self.current_source_id != source_id:
+            if self.current_message_id != message_id:
                 yield self.current_vector
                 self.current_vector = []
-                self.current_source_id = source_id
+                self.current_message_id = message_id
                 current_position += 1
 
                 if current_position % 10000 == 0:
@@ -77,9 +75,12 @@ class DbWordVectorIterator(object):
     def __len__(self):
         from django.db.models import Count
 
-        count = self.wv_class.objects.filter(dictionary=self.dictionary).aggregate(Count('source', distinct=True))
+        count = MessageWord.objects \
+            .filter(dictionary=self.dictionary) \
+            .aggregate(Count('message', distinct=True))
+
         if count:
-            return count['source__count']
+            return count['message__count']
 
 
 class Tokenizer(object):
@@ -111,25 +112,21 @@ class Tokenizer(object):
 
 
 class WordTokenizer(Tokenizer):
-
     def __init__(self, texts=None, stoplist=None):
         super(WordTokenizer, self).__init__(texts, stoplist)
 
         import nltk
+
         self._tokenize = nltk.word_tokenize
 
     def split(self, text):
         return self._tokenize(text)
 
 
-class TaskContext(object):
-    def __init__(self, name, queryset, textfield, word_vector_class, topic_vector_class, tokenizer, minimum_frequency=2,
-                 stoplist=None):
+class TopicContext(object):
+    def __init__(self, name, queryset, tokenizer, minimum_frequency=2, stoplist=None):
         self.name = name
         self.queryset = queryset
-        self.textfield = textfield
-        self.word_vector_class = word_vector_class
-        self.topic_vector_class = topic_vector_class
         self.tokenizer = tokenizer
         self.stoplist = stoplist
         self.minimum_frequency = minimum_frequency
@@ -157,7 +154,7 @@ class TaskContext(object):
 
 
     def build_dictionary(self):
-        texts = DbTextIterator(self.queryset, textfield=self.textfield)
+        texts = DbTextIterator(self.queryset)
 
         tokenized_texts = self.tokenizer(texts, stoplist=self.stoplist)
 
@@ -168,32 +165,30 @@ class TaskContext(object):
                                              settings=self.get_dict_settings())
 
     def bows_exist(self, dictionary):
-        return self.word_vector_class.objects.filter(dictionary=dictionary).exists()
+        return MessageWord.objects.filter(dictionary=dictionary).exists()
 
 
     def build_bows(self, dictionary):
-        texts = DbTextIterator(self.queryset, textfield=self.textfield)
+        texts = DbTextIterator(self.queryset)
         tokenized_texts = self.tokenizer(texts, stoplist=self.stoplist)
 
         dictionary._vectorize_corpus(queryset=self.queryset,
-                                     tokenizer=tokenized_texts,
-                                     wv_class=self.word_vector_class,
-                                     textfield=self.textfield)
+                                     tokenizer=tokenized_texts)
 
     def build_lda(self, dictionary, num_topics=30):
-        corpus = DbWordVectorIterator(dictionary, self.word_vector_class)
+        corpus = DbWordVectorIterator(dictionary)
         return dictionary._build_lda(self.name, corpus, num_topics=num_topics)
 
     def apply_lda(self, dictionary, model, lda=None):
-        corpus = DbWordVectorIterator(dictionary, self.word_vector_class)
-        return dictionary._apply_lda(model, corpus, topicvector_class=self.topic_vector_class, lda=lda)
+        corpus = DbWordVectorIterator(dictionary)
+        return dictionary._apply_lda(model, corpus, lda=lda)
 
     def evaluate_lda(self, dictionary, model, lda=None):
-        corpus = DbWordVectorIterator(dictionary, self.word_vector_class)
+        corpus = DbWordVectorIterator(dictionary)
         return dictionary._evaluate_lda(model, corpus, lda=lda)
 
 
-def data_pipeline(context, num_topics):
+def standard_topic_pipeline(context, num_topics):
     dictionary = context.find_dictionary()
     if dictionary is None:
         dictionary = context.build_dictionary()
@@ -206,15 +201,11 @@ def data_pipeline(context, num_topics):
     context.evaluate_lda(dictionary, model, lda)
 
 
-def get_message_context(name, dataset_id):
+def default_topic_context(name, dataset_id):
     dataset = Dataset.objects.get(pk=dataset_id)
     queryset = dataset.message_set.filter(language__code='en')
-    textfield = 'text'
 
-    return TaskContext(name=name, queryset=queryset,
-                       textfield=textfield,
-                       word_vector_class=MessageWord,
-                       topic_vector_class=MessageTopic,
-                       tokenizer=WordTokenizer,
-                       stoplist=get_stoplist(),
-                       minimum_frequency=4)
+    return TopicContext(name=name, queryset=queryset,
+                        tokenizer=WordTokenizer,
+                        stoplist=get_stoplist(),
+                        minimum_frequency=4)

--- a/msgvis/apps/enhance/tests.py
+++ b/msgvis/apps/enhance/tests.py
@@ -1,20 +1,115 @@
 from django.test import TestCase
 
-from models import set_message_sentiment
-from msgvis.apps.importer.models import create_an_instance_from_json
-from msgvis.apps.corpus.models import Dataset, Message
+from msgvis.apps.enhance import models, tasks
+from msgvis.apps.corpus import models as corpus_models
 
-# Create your tests here.
+
 class MessageSentimentTest(TestCase):
     def setUp(self):
-        self.dataset = Dataset.objects.create(name="Test Corpus", description="My Dataset")
+        self.dataset = corpus_models.Dataset.objects.create(name="Test Corpus", description="My Dataset")
 
     def test_sentiment(self):
         """Dataset.created_at should get set automatically."""
-        test_tweet = r"""{"contributors": null, "truncated": false, "text": "I hate that", "in_reply_to_status_id": null, "id": 562057573302431746, "favorite_count": 0, "source": "<a href=\"http://blackberry.com/twitter\" rel=\"nofollow\">Twitter for BlackBerry\u00ae</a>", "retweeted": false, "coordinates": null, "timestamp_ms": "1422839942657", "entities": {"user_mentions": [], "symbols": [], "trends": [], "hashtags": [{"indices": [93, 107], "text": "OurPriorities"}], "urls": []}, "in_reply_to_screen_name": null, "id_str": "562057573302431746", "retweet_count": 0, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": null, "profile_use_background_image": true, "default_profile_image": false, "id": 2223209961, "verified": false, "profile_image_url_https": "https://pbs.twimg.com/profile_images/451825921167994881/8XWideg5_normal.jpeg", "profile_sidebar_fill_color": "DDEEF6", "profile_text_color": "333333", "followers_count": 114, "profile_sidebar_border_color": "C0DEED", "id_str": "2223209961", "profile_background_color": "C0DEED", "listed_count": 4, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": null, "statuses_count": 4336, "description": "I don't exist. You don't exist. Nothing is real. But enjoy your non-real existence", "friends_count": 274, "location": "", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/451825921167994881/8XWideg5_normal.jpeg", "following": null, "geo_enabled": true, "profile_banner_url": "https://pbs.twimg.com/profile_banners/2223209961/1421816307", "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "name": "Melissa", "lang": "en", "profile_background_tile": false, "favourites_count": 1266, "screen_name": "Brooklyn_Newsie", "notifications": null, "url": "http://www.brunette-the-strange.pinterest.com", "created_at": "Fri Dec 13 10:57:43 +0000 2013", "contributors_enabled": false, "time_zone": null, "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Mon Feb 02 01:19:02 +0000 2015", "filter_level": "low", "in_reply_to_status_id_str": null, "place": null}"""
-        create_an_instance_from_json(test_tweet, self.dataset)
-        msg = Message.objects.all()[0]
-        set_message_sentiment(msg)
+        msg = self.dataset.message_set.create(
+            text="kitties are the worst awfullest animals and i hate them"
+        )
+        models.set_message_sentiment(msg)
+        self.assertEquals(msg.sentiment, corpus_models.Message.SENTIMENT_NEGATIVE)
 
-        self.assertEquals(msg.sentiment, Message.SENTIMENT_NEGATIVE)
+
+class TopicsTest(TestCase):
+    def setUp(self):
+        self.dataset = corpus_models.Dataset.objects.create(name="Test Corpus", description="My Dataset")
+
+        self.msg = self.dataset.message_set.create(
+            text="kitties are the worst awfullest animals and i hate them"
+        )
+
+        self.dictionary = models.Dictionary.objects.create(
+            name="test dictionary",
+            dataset="test dataset",
+        )
+
+        self.topic_model = self.dictionary.topicmodel_set.create(
+            name="test topic model",
+            description="test topic model",
+        )
+
+        self.topic = self.topic_model.topics.create(
+            name="test topic",
+            description="test topic",
+            index=0,
+            alpha=0
+        )
+
+    def test_get_topics_no_topics(self):
+        """When there are no topics, should return empty list of topics"""
+        self.assertEquals(self.msg.topics.count(), 0)
+
+    def test_get_topics_with_topics(self):
+        """If the message has topics, should return them"""
+        models.MessageTopic.objects.create(
+            topic_model=self.topic_model,
+            topic=self.topic,
+            probability=0.5,
+            message=self.msg,
+        )
+
+        self.assertEquals(self.msg.topics.count(), 1)
+        topic = self.msg.topics.first()
+        self.assertIsInstance(topic, models.Topic)
+
+    def test_topic_modeling(self):
+        """Generate some test messages and actually model topics"""
+        n_messages = 50
+        n_words = 5
+        num_topics = 2
+
+        from random import choice
+        import math
+
+        topic_a_vocab = ['cat', 'hat', 'marbles']
+        topic_b_vocab = ['oppossum', 'lasso', 'amalgam']
+        total_words = len(topic_a_vocab) + len(topic_b_vocab)
+
+        english, created = corpus_models.Language.objects.get_or_create(code='en', name="English")
+
+        for i in xrange(n_messages):
+            if i < n_messages / 2:
+                vocab = topic_a_vocab
+            else:
+                vocab = topic_b_vocab
+
+            self.dataset.message_set.create(
+                text=" ".join(choice(vocab) for w in xrange(n_words)),
+                language=english,
+            )
+
+        context = tasks.default_topic_context("test_topic_modeling", dataset_id=self.dataset.id)
+        tasks.standard_topic_pipeline(context, num_topics=num_topics)
+
+        dictionary = models.Dictionary.objects.get(name='test_topic_modeling')
+
+        # Check the basic stats of the dictionary
+        self.assertEquals(dictionary.num_docs, n_messages)
+        self.assertEquals(dictionary.num_pos, n_messages * n_words)
+
+        # Check the links to words
+        self.assertEquals(dictionary.words.count(), total_words)
+
+        # Check the links to topic models
+        self.assertEquals(dictionary.topicmodel_set.count(), 1)
+        topic_model = dictionary.topicmodel_set.first()
+        self.assertLess(topic_model.perplexity, -1)
+
+        # Check the number of topics
+        self.assertEquals(topic_model.topics.count(), num_topics)
+        topics = topic_model.topics.all()
+        topic_a = topics[0]
+        topic_b = topics[1]
+
+        # Should be the proper number of messages with positive topic probabilities
+        # The - 3 factor on the end allows a little wiggle room for randomness
+        self.assertGreater(topic_a.message_probabilities.filter(probability__gt=0.5).count(), n_messages / 2 - 3)
+        self.assertGreater(topic_b.message_probabilities.filter(probability__gt=0.5).count(), n_messages / 2 - 3)
 


### PR DESCRIPTION
Rewired the models inside the enhance app, so that topics and messages are related through a ManyToManyField with a through model. This should enable topics to be used like other categorical dimensions.

Also added an end-to-end test for the topic modeling procedure to make sure this didn't break that code (which I did change a bit).

Fix for #43.