### PR TITLE
Merge master and categorical filter without log axis

### DIFF
--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -209,3 +209,4 @@ class DataTableSerializer(serializers.Serializer):
     result = serializers.DictField(required=False, read_only=True)
     page_size = serializers.IntegerField(required=False)
     page = serializers.IntegerField(required=False)
+    search_key = serializers.CharField(allow_null=True, allow_blank=True, required=False)

--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -207,3 +207,5 @@ class DataTableSerializer(serializers.Serializer):
     dimensions = serializers.ListField(child=DimensionKeySerializer())
     filters = serializers.ListField(child=FilterSerializer(), required=False)
     result = serializers.DictField(required=False, read_only=True)
+    page_size = serializers.IntegerField(required=False)
+    page = serializers.IntegerField(required=False)

--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -206,6 +206,7 @@ class DataTableSerializer(serializers.Serializer):
     dataset = serializers.PrimaryKeyRelatedField(queryset=corpus_models.Dataset.objects.all())
     dimensions = serializers.ListField(child=DimensionKeySerializer())
     filters = serializers.ListField(child=FilterSerializer(), required=False)
+    exclude = serializers.ListField(child=FilterSerializer(), required=False)
     result = serializers.DictField(required=False, read_only=True)
     page_size = serializers.IntegerField(required=False)
     page = serializers.IntegerField(required=False)

--- a/msgvis/apps/api/tests/test_views.py
+++ b/msgvis/apps/api/tests/test_views.py
@@ -234,4 +234,7 @@ class DataTableViewTest(APITestCase):
 
         # It should have called the data table function
         DataTable.assert_called_once_with(*dimensions)
-        datatable.generate.assert_called_once_with(self.dataset.id, filters)
+        # TODO: instead of using these ugly parameters, change them into mock
+        datatable.generate.assert_called_once_with(self.dataset.id, filters, [], 30, None, None )
+
+        # TODO: write tests for paging and searching

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -111,6 +111,7 @@ class DataTableView(APIView):
             dataset = data['dataset']
             dimensions = data['dimensions']
             filters = data.get('filters', [])
+            exclude = data.get('exclude', [])
             search_key = data.get('search_key')
 
             page_size = 30
@@ -122,7 +123,7 @@ class DataTableView(APIView):
                 page = max(1, int(data.get('page')))
 
             datatable = datatable_models.DataTable(*dimensions)
-            result = datatable.generate(dataset, filters, page_size, page, search_key)
+            result = datatable.generate(dataset, filters, exclude, page_size, page, search_key)
 
             # Just add the result key
             response_data = data

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -113,7 +113,7 @@ class DataTableView(APIView):
             filters = data.get('filters', [])
             search_key = data.get('search_key')
 
-            page_size = 10
+            page_size = 30
             page = None
             if data.get('page_size'):
                 page_size = data.get('page_size')

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -111,9 +111,8 @@ class DataTableView(APIView):
             dataset = data['dataset']
             dimensions = data['dimensions']
             filters = data.get('filters', [])
+            search_key = data.get('search_key')
 
-
-            datatable = datatable_models.DataTable(*dimensions)
             page_size = 10
             page = None
             if data.get('page_size'):
@@ -122,8 +121,8 @@ class DataTableView(APIView):
             if data.get('page'):
                 page = max(1, int(data.get('page')))
 
-
-            result = datatable.generate(dataset, filters, page_size, page)
+            datatable = datatable_models.DataTable(*dimensions)
+            result = datatable.generate(dataset, filters, page_size, page, search_key)
 
             # Just add the result key
             response_data = data

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -112,8 +112,18 @@ class DataTableView(APIView):
             dimensions = data['dimensions']
             filters = data.get('filters', [])
 
+
             datatable = datatable_models.DataTable(*dimensions)
-            result = datatable.generate(dataset, filters)
+            page_size = 10
+            page = None
+            if data.get('page_size'):
+                page_size = data.get('page_size')
+                page_size = max(1, int(data.get('page_size')))
+            if data.get('page'):
+                page = max(1, int(data.get('page')))
+
+
+            result = datatable.generate(dataset, filters, page_size, page)
 
             # Just add the result key
             response_data = data

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -131,7 +131,7 @@ class DataTable(object):
 
         return match_domain, match_labels
 
-    def generate(self, dataset, filters=None, page_size=10, page=None, search_key=None):
+    def generate(self, dataset, filters=None, page_size=30, page=None, search_key=None):
         """
         Generate a complete data table response.
 

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -162,6 +162,7 @@ class DataTable(object):
         table = None
         domains = {}
         domain_labels = {}
+        max_page = None
 
         # Include the domains for primary and (secondary) dimensions
         domain, labels = self.domain(self.primary_dimension,
@@ -176,14 +177,11 @@ class DataTable(object):
                 domain, labels = self.filter_search_key(domain, labels, search_key)
             start = (page - 1) * page_size
             end = min(start + page_size, len(domain))
+            max_page = (len(domain) / page_size) + 1
 
             # no level left
             if len(domain) == 0 or start > len(domain):
-                return {
-                    'table': table,
-                    'domains': domains,
-                    'domain_labels': domain_labels,
-                }
+                return None
 
             domain = domain[start:end]
             if labels is not None:
@@ -214,9 +212,12 @@ class DataTable(object):
         # Render a table
         table = self.render(queryset)
 
-        return {
+        results = {
             'table': table,
             'domains': domains,
-            'domain_labels': domain_labels,
+            'domain_labels': domain_labels
         }
+        if max_page is not None:
+            results['max_page'] = max_page
 
+        return results

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -118,7 +118,20 @@ class DataTable(object):
 
         return domain, labels
 
-    def generate(self, dataset, filters=None, page_size=10, page=None):
+    def filter_search_key(self, domain, labels, search_key):
+        match_domain = []
+        match_labels = []
+        for i in range(len(domain)):
+            level = domain[i]
+            if level is not None and level.lower().find(search_key.lower()) != -1 :
+                match_domain.append(level)
+
+                if labels is not None:
+                    match_labels.append(labels[i])
+
+        return match_domain, match_labels
+
+    def generate(self, dataset, filters=None, page_size=10, page=None, search_key=None):
         """
         Generate a complete data table response.
 
@@ -158,8 +171,20 @@ class DataTable(object):
 
         # paging the first dimension, this is for the filter distribution
         if primary_filter is None and self.secondary_dimension is None and page is not None:
+
+            if search_key is not None:
+                domain, labels = self.filter_search_key(domain, labels, search_key)
             start = (page - 1) * page_size
-            end = start + page_size
+            end = min(start + page_size, len(domain))
+
+            # no level left
+            if len(domain) == 0 or start > len(domain):
+                return {
+                    'table': table,
+                    'domains': domains,
+                    'domain_labels': domain_labels,
+                }
+
             domain = domain[start:end]
             if labels is not None:
                 labels = labels[start:end]

--- a/msgvis/apps/dimensions/models.py
+++ b/msgvis/apps/dimensions/models.py
@@ -101,6 +101,9 @@ class CategoricalDimension(object):
         for level in kwargs.get('levels'):
             if level is None or level == "":
                 queryset = queryset.exclude(Q((self.field_name + "__isnull", True)))
+
+                # TODO: Should not need this, but the language data contains empty str
+                queryset = queryset.exclude(Q((self.field_name, "")))
             else:
                 queryset = queryset.exclude(Q((self.field_name, level)))
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -316,7 +316,7 @@
     });
 
     module.directive('categoricalHistogram', function () {
-        
+
         var get_scale = function(dimension, width){
             var values = dimension.table.map(function(d){ return d.value; });
             var scale = d3.scale.linear();
@@ -387,7 +387,6 @@
 
         }
     });
-
 
     module.directive('sparqsVis', function () {
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -334,7 +334,8 @@
                 var scale = get_scale(scope.dimension, elementSize.width * 0.1);
                 var $d3_element = d3.select($element[0]);
                 var d3_select = $d3_element.selectAll('.level-div')
-                    .data(scope.dimension.distribution);
+                    .data(scope.dimension.distribution)
+                    .classed('active', true);
                 d3_select.enter()
                     .append('div')
                     .classed('level-div', true)
@@ -352,11 +353,12 @@
                     .each(function(d){
                         var self = d3.select(this);
                         self.classed('active', false);
-                        self.hide();
+                        self.style('display', 'none');
                     });
                 $d3_element.selectAll('.level-div.active')
                     .each(function(d){
                         var self = d3.select(this);
+                        self.style('display', 'block');
                         self.select('.level-show').attr('checked', (d.show) ? "checked" : null);
                         self.select('.level-name-text').text(d.label || d.level);
                         self.select('.level-value').text(d.value);
@@ -373,7 +375,6 @@
             scope.$watch('dimension.distribution.length', function (newVals, oldVals) {
                     if (newVals) return render_bar(scope, $element, attrs);
             }, false);
-
         }
 
         return {

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -435,6 +435,8 @@
                         valueLabelsInverse[idx] = value;
                     }else{
                         valueLabelsInverse[label.toString()] = value;
+                        if (valueLabelsInverse[label.toString()] == null)
+                            valueLabelsInverse[label.toString()] = "";
                     }
                 });
 
@@ -597,6 +599,12 @@
                 //Default setup: one-axis bar chart vs. counts
 
                 var config = {
+                    size: {
+                        height: 600
+                    },
+                    padding: {
+                        bottom: 80
+                    },
                     data:{
                         type: 'bar',
                         x: primary.key,
@@ -619,10 +627,12 @@
                                 position: 'outer-middle'
                             }
                         }
+
                     },
                     legend: {
                         show: false
                     }
+
                 };
 
                 //If x is quantitative, use a line chart
@@ -668,15 +678,22 @@
                     } else {
                         // The secondary dimension is categorical, so it
                         // requires a legend to reveal the groups.
-
                         config.legend.show = true;
                         config.legend.position = 'inset';
                         config.legend.inset = {
                             anchor: 'top-right',
                             x: 20,
-                            y: 10,
+                            y: 520,
                             step: 2
                         };
+                        var num_of_levels = domains[secondary.key].length;
+                        if ( num_of_levels > 12 ){
+                            config.legend.inset.step = 5;
+                            config.legend.inset.y = 450;
+                            config.padding.bottom = 150;
+
+
+                        }
                     }
                 }
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -381,9 +381,38 @@
             }
         };
 
+        var reset_levels = function(scope, $element, attrs){
+            if ( typeof(scope.dimension) !== "undefined" ){
+                var reset_value = {'filter': false, 'exclude': true};
+                var $d3_element = d3.select($element[0]);
+                scope.dimension.distribution.forEach(function(d){
+                    d.show = reset_value[scope.dimension.mode];
+                });
+
+                $d3_element.selectAll('.level-div.active')
+                    .each(function(d){
+                        var self = d3.select(this);
+
+                        // turn of the event handler first
+                        self.select('.level-show').on('change', null);
+                        $(this).find('.level-show').prop('checked', reset_value[scope.dimension.mode]);
+                        self.select('.level-show').on('change', function(d){
+                                var checked = $(this).prop("checked");
+                                d.show = checked;
+                                scope.dimension.change_level(d);
+                            });
+                    });
+
+
+            }
+        };
+
         function link(scope, $element, attrs){
             scope.$watch('dimension.distribution.length', function (newVals, oldVals) {
                     if (newVals) return render_bar(scope, $element, attrs);
+            }, false);
+            scope.$watch('dimension.mode', function (newVals, oldVals) {
+                    if (newVals) return reset_levels(scope, $element, attrs);
             }, false);
         }
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -342,10 +342,20 @@
                     .each(function(d){
                         var self = d3.select(this);
                         self.classed('active', true);
-                        var level_name = self.append('div').classed('level-name', true);
-                        var label = level_name.append('label');
-                        label.append('input').attr('type', 'checkbox').classed('level-show', true);
+
+                        var label = self.append('div')
+                            .classed('level-name', true)
+                            .append('label');
+                        label.append('input')
+                            .attr('type', 'checkbox')
+                            .classed('level-show', true)
+                            .on('change', function(d){
+                                var checked = $(this).prop("checked");
+                                d.show = checked;
+                                scope.dimension.change_level(d);
+                            });
                         label.append('span').classed('level-name-text', true);
+
                         self.append('div').classed('level-value', true);
                         self.append('div').classed('level-bar', true);
                     });
@@ -359,7 +369,7 @@
                     .each(function(d){
                         var self = d3.select(this);
                         self.style('display', 'block');
-                        self.select('.level-show').attr('checked', (d.show) ? "checked" : null);
+                        $(this).find('.level-show').prop('checked', (d.show) ? true : false);
                         self.select('.level-name-text').text(d.label || d.level);
                         self.select('.level-value').text(d.value);
                         self.select('.level-bar')

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -315,6 +315,63 @@
         };
     });
 
+    /*module.directive('categoricalHistogram', function () {
+
+
+        var dimensionScale = {};
+        var setup_dimension_scale = function(dimension, width){
+            var values = dimension.table.map(function(d){ return d.value; });
+            var scale = d3.scale.linear();
+            scale.domain([0, d3.max(values)]);
+            scale.range([0, width]);
+            dimensionScale[dimension.key] = scale;
+        };
+        var create_bar = function($element, dimension, level_value) {
+            var elementSize = {
+                width: $element.parent().width(),
+                height: $element.parent().height()
+            };
+            var $d3_element = d3.select($element[0]);
+            var div = $d3_element.append("div");
+            div.style("width", (dimensionScale[dimension.key](level_value)) + "px");
+            div.style("height", (elementSize.height * 0.7) + "px");
+
+        };
+
+        var render_bar = function(scope, $element, attrs){
+            if ( typeof(scope.dimension) !== "undefined" ){
+                var elementSize = {
+                    width: $element.parent().width(),
+                    height: $element.parent().height()
+                };
+                if ( typeof(dimensionScale[scope.dimension.key]) === "undefined" ){
+                    setup_dimension_scale(scope.dimension, elementSize.width);
+                }
+                create_bar($element, scope.dimension, scope.levelValue);
+
+            }
+        };
+
+        function link(scope, $element, attrs){
+            scope.$watch('dimension.distribution', function (newVals, oldVals) {
+                    if (newVals) return render_bar(scope, $element, attrs);
+            }, false);
+
+        }
+
+        return {
+            restrict: 'E',
+            replace: false,
+
+            scope: {
+                dimension: '=dimension',
+                levelValue: '=levelValue'
+            },
+            link: link
+
+        }
+    });*/
+
     module.directive('categoricalHistogram', function () {
 
 
@@ -371,6 +428,7 @@
 
         }
     });
+
 
     module.directive('sparqsVis', function () {
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -670,10 +670,10 @@
 
                 var config = {
                     size: {
-                        height: 600
+                        height: 500
                     },
                     padding: {
-                        bottom: 80
+                        //bottom: 80
                     },
                     data:{
                         type: 'bar',
@@ -753,14 +753,14 @@
                         config.legend.inset = {
                             anchor: 'top-right',
                             x: 20,
-                            y: 520,
+                            y: 20,
                             step: 2
                         };
                         var num_of_levels = domains[secondary.key].length;
                         if ( num_of_levels > 12 ){
-                            config.legend.inset.step = 5;
-                            config.legend.inset.y = 450;
-                            config.padding.bottom = 150;
+                            config.legend.inset.step = 6;
+                            //config.legend.inset.y = 450;
+                            //config.padding.bottom = 150;
 
 
                         }

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -348,12 +348,7 @@
                             .append('label');
                         label.append('input')
                             .attr('type', 'checkbox')
-                            .classed('level-show', true)
-                            .on('change', function(d){
-                                var checked = $(this).prop("checked");
-                                d.show = checked;
-                                scope.dimension.change_level(d);
-                            });
+                            .classed('level-show', true);
                         label.append('span').classed('level-name-text', true);
 
                         self.append('div').classed('level-value', true);
@@ -370,6 +365,11 @@
                         var self = d3.select(this);
                         self.style('display', 'block');
                         $(this).find('.level-show').prop('checked', (d.show) ? true : false);
+                        self.select('.level-show').on('change', function(d){
+                                var checked = $(this).prop("checked");
+                                d.show = checked;
+                                scope.dimension.change_level(d);
+                            });
                         self.select('.level-name-text').text(d.label || d.level);
                         self.select('.level-value').text(d.value);
                         self.select('.level-bar')

--- a/msgvis/static/SparQs/controllers.js
+++ b/msgvis/static/SparQs/controllers.js
@@ -220,6 +220,7 @@
 
     //Extends DimensionsController
     var FilterController = function ($scope, Filtering, Selection) {
+
         $scope.filtering = Filtering;
 
         $scope.closeFilter = function() {
@@ -249,7 +250,11 @@
 
         $scope.onQuantitativeBrushed = function(min, max) {
             $scope.$digest();
-        }
+        };
+
+        $scope.loadMore = function() {
+            Filtering.dimension.load_categorical_distribution();
+        };
 
 
     };
@@ -278,5 +283,21 @@
           });
         }
       }
+    });
+
+    module.directive('whenScrolled', function() {
+        return function(scope, element, attr) {
+            var raw = element[0];
+
+            var checkBounds = function(evt) {
+                console.log("event fired: " + evt.type);
+                if (raw.scrollTop + $(raw).height() == raw.scrollHeight) {
+                    console.log("reach the bottom");
+                    scope.$apply(attr.whenScrolled);
+                }
+
+            };
+            element.bind('scroll load', checkBounds);
+        };
     });
 })();

--- a/msgvis/static/SparQs/controllers.js
+++ b/msgvis/static/SparQs/controllers.js
@@ -99,8 +99,9 @@
 
         $scope.get_example_messages = function () {
             var filters = Selection.filters();
+            var exclude = Selection.exclude();
             var focus = Selection.focus();
-            ExampleMessages.load(Dataset.id, filters, focus);
+            ExampleMessages.load(Dataset.id, filters, focus, exclude);
         };
 
         Selection.changed('filters,focus', $scope, $scope.get_example_messages);
@@ -165,7 +166,8 @@
         $scope.get_data_table = function () {
             var dimensions = Selection.dimensions();
             var filters = Selection.filters();
-            DataTables.load(Dataset.id, dimensions, filters);
+            var exclude = Selection.exclude();
+            DataTables.load(Dataset.id, dimensions, filters, exclude);
         };
 
         $scope.get_data_table();
@@ -228,23 +230,22 @@
         };
 
         $scope.saveFilter = function () {
-            if (Filtering.dimension.filter.dirty) {
+            if (Filtering.dimension.is_dirty()) {
                 Selection.changed('filters');
-                Filtering.dimension.filter.saved();
+                Filtering.dimension.current_filter().saved();
             }
         };
 
         $scope.resetFilter = function () {
-            if (!Filtering.dimension.filter.is_empty()) {
+            if (!Filtering.dimension.current_filter().is_empty()) {
                 if (Filtering.dimension.is_categorical()){
-                    Filtering.dimension.filtered_all(false);
                     if ( typeof(Filtering.dimension.search) != "undefined")
                         Filtering.dimension.search.level = "";
                 }else{
-                    Filtering.dimension.filter.reset();
+                    Filtering.dimension.current_filter().reset();
                 }
                 Selection.changed('filters');
-                Filtering.dimension.filter.saved();
+                Filtering.dimension.current_filter().saved();
             }
         };
 

--- a/msgvis/static/SparQs/controllers.js
+++ b/msgvis/static/SparQs/controllers.js
@@ -239,8 +239,8 @@
         $scope.resetFilter = function () {
             if (!Filtering.dimension.current_filter().is_empty()) {
                 if (Filtering.dimension.is_categorical()){
-                    if ( typeof(Filtering.dimension.search) != "undefined")
-                        Filtering.dimension.search.level = "";
+                    Filtering.dimension.search_key = "";
+                    Filtering.dimension.search_key_tmp = "";
                 }else{
                     Filtering.dimension.current_filter().reset();
                 }
@@ -256,6 +256,17 @@
         $scope.loadMore = function() {
             Filtering.dimension.load_categorical_distribution();
         };
+
+        $scope.search = function() {
+            Filtering.dimension.search_key = Filtering.dimension.search_key_tmp;
+            Filtering.dimension.load_categorical_distribution();
+        };
+        $scope.set_back_cur_search = function() {
+            if ( Filtering.dimension.search_key_tmp !== Filtering.dimension.search_key )
+                Filtering.dimension.search_key_tmp = Filtering.dimension.search_key;
+
+        };
+
 
 
     };
@@ -291,9 +302,7 @@
             var raw = element[0];
 
             var checkBounds = function(evt) {
-                console.log("event fired: " + evt.type);
                 if (raw.scrollTop + $(raw).height() == raw.scrollHeight) {
-                    console.log("reach the bottom");
                     scope.$apply(attr.whenScrolled);
                 }
 
@@ -301,4 +310,19 @@
             element.bind('scroll load', checkBounds);
         };
     });
+
+    module.directive('ngEnter', function () {
+        return function (scope, element, attrs) {
+            element.bind("keydown keypress", function (event) {
+                if(event.which === 13) {
+                    scope.$apply(function (){
+                        scope.$eval(attrs.ngEnter);
+                    });
+
+                    event.preventDefault();
+                }
+            });
+        };
+    });
+
 })();

--- a/msgvis/static/SparQs/services.js
+++ b/msgvis/static/SparQs/services.js
@@ -136,7 +136,15 @@
 
                     //Prepare filter data
                     return with_filter.map(function (dim) {
-                        return dim.serialize_filter();
+                        return dim.serialize_filter('filter');
+                    })
+                },
+                exclude: function () {
+                    var with_exclude = Dimensions.get_with_exclude();
+
+                    //Prepare filter data
+                    return with_exclude.map(function (dim) {
+                        return dim.serialize_filter('exclude');
                     })
                 },
                 focus: function () {
@@ -166,6 +174,7 @@
                         var dim = {};
                         dim.dimension = dimensions[i].key;
                         dim.value = click_point_values[i];
+
                         if (typeof(dim.value) === "undefined") {
                             dim.value = "";
                         }
@@ -197,11 +206,12 @@
             };
 
             angular.extend(ExampleMessages.prototype, {
-                load: function (dataset, filters, focus) {
+                load: function (dataset, filters, focus, exclude) {
 
                     var request = {
                         dataset: dataset,
                         filters: filters,
+                        exclude: exclude,
                         focus: focus
                     };
 
@@ -234,7 +244,7 @@
             };
 
             angular.extend(DataTables.prototype, {
-                load: function (dataset, dimensions, filters) {
+                load: function (dataset, dimensions, filters, exclude) {
                     if (!dimensions.length) {
                         return;
                     }
@@ -246,6 +256,7 @@
                     var request = {
                         dataset: dataset,
                         filters: filters,
+                        exclude: exclude,
                         dimensions: dimension_keys
                     };
 

--- a/msgvis/static/SparQs/services.js
+++ b/msgvis/static/SparQs/services.js
@@ -92,7 +92,12 @@
                 },
                 get_filtered: function () {
                     return Dimensions.list.filter(function (dim) {
-                        return !dim.filter.is_empty();
+                        return !dim.filter_type['filter'].is_empty();
+                    });
+                },
+                get_exclude: function () {
+                    return Dimensions.list.filter(function (dim) {
+                        return !dim.filter_type['exclude'].is_empty();
                     });
                 }
             });
@@ -140,7 +145,7 @@
                     })
                 },
                 exclude: function () {
-                    var with_exclude = Dimensions.get_with_exclude();
+                    var with_exclude = Filtering.get_exclude();
 
                     //Prepare filter data
                     return with_exclude.map(function (dim) {

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -123,7 +123,7 @@
                         cls += 'dimension-' + this.zone.name;
                     }
 
-                    if (!this.filter.is_empty()) {
+                    if (!this.is_not_applying_filters()) {
                         cls += ' filter-applied';
                     }
 
@@ -160,6 +160,14 @@
                             this.load_distribution()
                         }
                     }
+                },
+                is_not_applying_filters: function(){
+                    return this.filter_type['filter'].is_empty() &&
+                           this.filter_type['exclude'].is_empty();
+                },
+                is_dirty: function(){
+                    return this.filter_type['filter'].dirty ||
+                           this.filter_type['exclude'].dirty;
                 },
                 load_distribution: function (dataset) {
                     if (this.is_categorical() && !this.table){

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -272,8 +272,6 @@
                         distribution_map[level] = d.value;
                     });
 
-                    dimension.num_default_show = 5;
-
                     return domain.map(function(level, i) {
                         var value = distribution_map[level] || 0;
 
@@ -289,7 +287,7 @@
                             level: level,
                             label: label,
                             value: value,
-                            show: (i < dimension.num_default_show)
+                            show: dimension.mode == "exclude" ? true : false
                         };
                     });
                 },
@@ -307,38 +305,34 @@
                         this.filter_type[this.mode].remove_from_levels(this.inverse_level(d.level));
                     }
                 },
+                switch_mode: function(mode){
+                    if ( mode !== 'exclude' && mode !== "filter" ) return;
+                    this.mode = mode;
+                    for (var m in this.filter_type){
+                        this.filter_type[m].reset();
+                    }
+
+                },
                 /*unfilter_level: function (d) {
                     d.show = true;
                     this.filter.levels().push(this.inverse_level(d.level));
 
                     this.filter_dirty = true;
 
-                },
-                change_level: function (d) {
-                    if (d.show == true) {
-                        this.filter.levels().push(this.inverse_level(d.level));
-                    } else {
-                        var idx = this.filter.levels().indexOf(this.inverse_level(d.level));
-                        if (idx != -1) {
-                            this.filter.levels().splice(idx, 1);
-                        }
-                    }
-                    this.filter_dirty = true;
-
-                },
+                }*/
                 is_all_filtered: function () {
-                    if (typeof (this.filter.levels()) !== "undefined") {
+                    /*if (typeof (this.filter.levels()) !== "undefined") {
                         return this.is_categorical() && this.filter.levels().length == 0;
-                    }
+                    }*/
                     return false;
                 },
                 is_not_filtered: function () {
-                    if (typeof (this.filter.levels()) !== "undefined") {
+                    /*if (typeof (this.filter.levels()) !== "undefined") {
                         return this.is_categorical() && this.filter.levels().length == this.domain.length;
-                    }
+                    }*/
                     return false;
                 },
-                filtered_all: function (flag) {
+                /*filtered_all: function (flag) {
                     var dimension = this;
                     if (typeof (dimension.filter.levels()) !== "undefined") {
                         if (flag == true) {

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -137,7 +137,7 @@
                     }
                 },
                 load_distribution: function (dataset) {
-                    if (this.is_categorical()){
+                    if (this.is_categorical() && !this.table){
                         return this.load_categorical_distribution(dataset, undefined);
                     }
                     else if (!this._loading && !this.table) {
@@ -201,7 +201,7 @@
                                 var result = data.result;
                                 self._loading = false;
 
-                                if ( typeof(result) !== "undefined" ){
+                                if ( result !== null && typeof(result) !== "undefined" ){
                                     result.table = result.table;
                                     result.domain = result.domains[self.key];
                                     result.domain_labels = result.domain_labels[self.key] || {};

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -177,6 +177,12 @@
                     }
                     return undefined;
                 },
+                inverse_level: function(level){
+                     var dimension = this;
+                    if ( level == "No " + dimension.key )
+                        return "";
+                    return level;
+                },
                 get_distribution_in_order: function (table, domain, labels) {
                     if (!table || !domain) {
                         return undefined;
@@ -214,16 +220,16 @@
                 },
                 unfilter_level: function (d) {
                     d.show = true;
-                    this.filter.levels().push(d.level);
+                    this.filter.levels().push(this.inverse_level(d.level));
 
                     this.filter.dirty = true;
 
                 },
                 change_level: function (d) {
                     if (d.show == true) {
-                        this.filter.levels().push(d.level);
+                        this.filter.levels().push(this.inverse_level(d.level));
                     } else {
-                        var idx = this.filter.levels().indexOf(d.level);
+                        var idx = this.filter.levels().indexOf(this.inverse_level(d.level));
                         if (idx != -1) {
                             this.filter.levels().splice(idx, 1);
                         }

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -141,7 +141,8 @@
 
                         var request = {
                             dataset: Dataset.id,
-                            dimensions: [this.key]
+                            dimensions: [this.key],
+                            page: 1
                         };
 
                         var apiUrl = djangoUrl.reverse('data-table');

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -699,17 +699,17 @@ body {
     .level-select-button:disabled{
         color: #333;
     }
-    .search{
+    .search {
         font-size: 0.5em;
         text-align: left;
         margin-top: 1.5em;
-    }
-    .search input{
-        color: black;
-        line-height: 0.5em;
-    }
-    .search .glyphicon-remove:hover{
-        cursor: pointer;
+        input {
+          color: black;
+          line-height: 0.5em;
+        }
+        .glyphicon:hover {
+          cursor: pointer;
+        }
     }
 
 }

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -486,8 +486,13 @@ body {
 //                }
 //            }
         }
-
-
+        .c3-legend-background{
+            stroke: none;
+            fill: none;
+        }
+        .c3-legend-item text{
+                fill: white;
+        }
     }
 }
 

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -639,39 +639,37 @@ body {
         overflow-y: auto;
 
     }
-    .dimension-level{
-        text-align: left;
-        height: 1.1em;
-    }
-    .dimension-level div{
-        display: inline-block;
-        font-weight: normal;
-        font-size: 0.9em;
-        line-height: 1em;
-        padding: 0;
-        margin: 0;
-    }
-    .dimension-level .level-name{
-        width: @filter-popup-width * 0.65;
-
-    }
-    .dimension-level label{
-        font-weight: normal;
-
-    }
-    .dimension-level .level-value{
-        width: @filter-popup-width * 0.1;
-        text-align: right;
-    }
-    .dimension-level .level-bar{
-        width: @filter-popup-width * 0.08;
-        height: 1em;
-
-    }
+    
     categorical-histogram{
+        .level-div{
+            text-align: left;
+            height: 1.1em;
+            div{
+                display: inline-block;
+                font-weight: normal;
+                font-size: 0.9em;
+                line-height: 1em;
+                padding: 0;
+                margin: 0 1px;
+            }
+            .level-name{
+                width: @filter-popup-width * 0.60;
 
-        div {
-           background-color: steelblue;
+            }
+            label{
+                font-weight: normal;
+
+            }
+            .level-value{
+                width: @filter-popup-width * 0.1;
+                text-align: right;
+            }
+            .level-bar{
+                width: @filter-popup-width * 0.1;
+                height: 1em;
+                background-color: steelblue;
+
+            }
         }
     }
     .selected-levels{

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -377,9 +377,23 @@ body {
         left: @secondary-dropzone-width + @dropzone-buffer;
         bottom: @primary-dropzone-height + @dropzone-buffer;
 
-        svg {
-            background: white;
+        .c3-axis-y tspan,.c3-axis-x tspan,.c3-axis-x-label,.c3-axis-y-label{
+            fill: white;
         }
+        .domain,.tick line{
+            stroke: #999;
+        }
+        .c3-area{
+            opacity: 0.75;
+        }
+        .c3-legend-background{
+            stroke: none;
+            fill: none;
+        }
+        .c3-legend-item text{
+                fill: white;
+        }
+
     }
 
     .dropzones {

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -233,38 +233,29 @@
 
                         <div class="form-group" ng-switch-when="CategoricalDimension">
                             <div class="search" ng-show="filtering.dimension.show_search()">
-                                Search: <input type="text" ng-model="filtering.dimension.search.level" />
+                                Search: <input type="text"
+                                               ng-enter="search()"
+                                               ng-blur="set_back_cur_search()"
+                                               ng-model="filtering.dimension.search_key_tmp" />
+                                <span class="glyphicon glyphicon-search"
+                                      ng-show="filtering.dimension.search_key_tmp"
+                                      ng-click="search()"   ></span>
                                 <span class="glyphicon glyphicon-remove"
-                                      ng-show="filtering.dimension.search.level"
+                                      ng-show="filtering.dimension.search_key_tmp"
                                       ng-click="filtering.dimension.reset_search()"   ></span>
                             </div>
                             <hr />
                             <div class="level-select-button-group">
-                                <button type=button class="level-select-button"
+                                <button type=button class="level-select-button all"
                                         ng-click="filtering.dimension.switch_mode('exclude')"
-                                        ng-disabled="filtering.dimension.is_not_filtered()">Select All</button>
-                                <button type=button class="level-select-button"
+                                        >Select All</button>
+                                <button type=button class="level-select-button none"
                                         ng-click="filtering.dimension.switch_mode('filter')"
-                                        ng-disabled="filtering.dimension.is_all_filtered()">Unselected All</button>
+                                        >Unselected All</button>
                             </div>
 
 
                             <div class="dimension-levels" when-scrolled="loadMore()">
-
-                                <!--
-                                <div class=dimension-level ng-repeat="d in filtering.dimension.distribution | filter: filtering.dimension.search">
-                                    <div class="level-name">
-                                        <label><input type="checkbox" ng-model="d.show" ng-change="filtering.dimension.change_level(d)" /> {$ d.label || d.level $} </label>
-                                    </div>
-                                    <div class="level-value">{$ d.value $}</div>
-                                    <div class="level-bar">
-                                        <categorical-histogram
-                                                dimension="filtering.dimension"
-                                                level-value="d.value">
-                                        </categorical-histogram>
-                                    </div>
-                                </div>
-                                -->
                                 <categorical-histogram
                                     dimension="filtering.dimension" >
                                 </categorical-histogram>
@@ -282,9 +273,6 @@
 
                             </div>
                             -->
-
-
-
                         </div>
 
 

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -270,16 +270,18 @@
                                 </categorical-histogram>
                             </div>
                             <hr />
+                            <!--
                             <div class="selected-levels">
                                 <strong>Filter out levels:</strong> <br />
                                 <span class=dimension-level-filter
                                       ng-repeat="d in filtering.dimension.distribution"
-                                      ng-click="filtering.dimension.unfilter_level(d)"
                                       ng-show="!d.show">
+                                    ng-click="filtering.dimension.unfilter_level(d)"
                                     {$ d.level $}
                                 </span>
 
                             </div>
+                            -->
 
 
 
@@ -291,7 +293,6 @@
 
                     <div class="form-group form-buttons">
                         <button type="submit" class="btn btn-sm btn-primary apply-button"
-                                ng-disabled="!filtering.dimension.filter.dirty"
                                 ng-click="saveFilter()">Update</button>
                         <button type="button" class="btn btn-sm btn-default clear-button"
                                 ng-disabled="filtering.dimension.filter.is_empty()"

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -241,10 +241,10 @@
                             <hr />
                             <div class="level-select-button-group">
                                 <button type=button class="level-select-button"
-                                        ng-click="filtering.dimension.filtered_all(false)"
+                                        ng-click="filtering.dimension.switch_mode('exclude')"
                                         ng-disabled="filtering.dimension.is_not_filtered()">Select All</button>
                                 <button type=button class="level-select-button"
-                                        ng-click="filtering.dimension.filtered_all(true)"
+                                        ng-click="filtering.dimension.switch_mode('filter')"
                                         ng-disabled="filtering.dimension.is_all_filtered()">Unselected All</button>
                             </div>
 

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -251,6 +251,7 @@
 
                             <div class="dimension-levels">
 
+                                <!--
                                 <div class=dimension-level ng-repeat="d in filtering.dimension.distribution | filter: filtering.dimension.search">
                                     <div class="level-name">
                                         <label><input type="checkbox" ng-model="d.show" ng-change="filtering.dimension.change_level(d)" /> {$ d.label || d.level $} </label>
@@ -263,7 +264,10 @@
                                         </categorical-histogram>
                                     </div>
                                 </div>
-
+                                -->
+                                <categorical-histogram
+                                    dimension="filtering.dimension">
+                                </categorical-histogram>
                             </div>
                             <hr />
                             <div class="selected-levels">

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -249,7 +249,7 @@
                             </div>
 
 
-                            <div class="dimension-levels">
+                            <div class="dimension-levels" when-scrolled="loadMore()">
 
                                 <!--
                                 <div class=dimension-level ng-repeat="d in filtering.dimension.distribution | filter: filtering.dimension.search">
@@ -266,7 +266,7 @@
                                 </div>
                                 -->
                                 <categorical-histogram
-                                    dimension="filtering.dimension">
+                                    dimension="filtering.dimension" >
                                 </categorical-histogram>
                             </div>
                             <hr />

--- a/msgvis/templates/explorer.html
+++ b/msgvis/templates/explorer.html
@@ -250,6 +250,7 @@
 
 
                             <div class="dimension-levels">
+
                                 <div class=dimension-level ng-repeat="d in filtering.dimension.distribution | filter: filtering.dimension.search">
                                     <div class="level-name">
                                         <label><input type="checkbox" ng-model="d.show" ng-change="filtering.dimension.change_level(d)" /> {$ d.label || d.level $} </label>
@@ -262,6 +263,7 @@
                                         </categorical-histogram>
                                     </div>
                                 </div>
+
                             </div>
                             <hr />
                             <div class="selected-levels">


### PR DESCRIPTION
mainly for #114 and #118 

Major change:
- change chart style to make it look better
- add exclude to data table and example message apis
- rewrite categorical filters so that it is a single directive element with D3 data binding
- automatically load more levels when scrolling to the bottom
- change level search function from angular version to backend search
- make categorical filter UI to use filter/exclude separately (switch by select all/unselect all)

More TODOs:
- write tests for exclude, paging, search
- disable select all/unseclect all accordingly
   (I have tried a couple of different ways but none of them working.)
- Make the scroll back to top when changing filter (See #122 )