### PR TITLE
Default categorial filter

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     "angular-sanitize": "~1.3.13",
     "moment": "~2.9.0",
     "d3": "^3.5",
-    "c3": "~0.4.9"
+    "c3": "https://github.com/hds-lab/c3.git"
   }
 }

--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -211,3 +211,4 @@ class DataTableSerializer(serializers.Serializer):
     page_size = serializers.IntegerField(required=False)
     page = serializers.IntegerField(required=False)
     search_key = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+    mode = serializers.CharField(allow_null=True, allow_blank=True, required=False)

--- a/msgvis/apps/api/views.py
+++ b/msgvis/apps/api/views.py
@@ -113,6 +113,7 @@ class DataTableView(APIView):
             filters = data.get('filters', [])
             exclude = data.get('exclude', [])
             search_key = data.get('search_key')
+            mode = data.get('mode')
 
             page_size = 30
             page = None
@@ -123,6 +124,8 @@ class DataTableView(APIView):
                 page = max(1, int(data.get('page')))
 
             datatable = datatable_models.DataTable(*dimensions)
+            if mode is not None:
+                datatable.set_mode(mode)
             result = datatable.generate(dataset, filters, exclude, page_size, page, search_key)
 
             # Just add the result key

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -216,6 +216,7 @@ class DataTable(object):
                     r[self.primary_dimension.key] = u'others'
                 return secondary_results
 
+            # primary quantitative and secondary categorical
             elif not self.primary_dimension.is_categorical() and self.secondary_dimension.is_categorical():
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.secondary_dimension.field_name, domains[self.secondary_dimension.key]))
                 domains[self.secondary_dimension.key].append(u'others')

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -152,9 +152,9 @@ class DataTable(object):
             # on that dimension's group_by() implementation.
 
             queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
-            domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
+            domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.name)
 
-            return [{self.primary_dimension.key: u'Other ' + self.primary_dimension.key, 'value': queryset_for_others.count()}]
+            return [{self.primary_dimension.key: u'Other ' + self.primary_dimension.name, 'value': queryset_for_others.count()}]
 
         elif self.secondary_dimension:
 
@@ -163,17 +163,17 @@ class DataTable(object):
                 original_queryset = queryset_for_others
                 others_results = []
                 if primary_flag:
-                    domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
+                    domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.name)
                 if secondary_flag:
-                    domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.key)
+                    domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.name)
 
                 # primary others x secondary others
                 if primary_flag and secondary_flag:
                     queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
                     queryset_for_others = queryset_for_others.exclude(levels_or(self.secondary_dimension.field_name, domains[self.secondary_dimension.key]))
 
-                    others_results.append({self.primary_dimension.key: u'Other ' + self.primary_dimension.key,
-                                           self.secondary_dimension.key: u'Other ' + self.secondary_dimension.key,
+                    others_results.append({self.primary_dimension.key: u'Other ' + self.primary_dimension.name,
+                                           self.secondary_dimension.key: u'Other ' + self.secondary_dimension.name,
                                            'value': queryset_for_others.count()})
 
                 # primary top ones x secondary others
@@ -188,7 +188,7 @@ class DataTable(object):
                     queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
                     results = list(queryset_for_others)
                     for r in results:
-                        r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.key
+                        r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.name
                     others_results.extend(results)
 
                 # primary others x secondary top ones
@@ -203,7 +203,7 @@ class DataTable(object):
                     queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
                     results = list(queryset_for_others)
                     for r in results:
-                        r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.key
+                        r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.name
                     others_results.extend(results)
 
                 return others_results
@@ -211,27 +211,27 @@ class DataTable(object):
             # primary categorical and secondary quantitative
             elif self.primary_dimension.is_categorical() and primary_flag and not self.secondary_dimension.is_categorical():
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
-                domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
+                domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.name)
                 queryset_for_others = self.secondary_dimension.group_by(queryset_for_others,
                                                                         grouping_key=self.secondary_dimension.key,
                                                                         bins=desired_secondary_bins)
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
                 results = list(queryset_for_others)
                 for r in results:
-                    r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.key
+                    r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.name
                 return results
 
             # primary quantitative and secondary categorical
             elif not self.primary_dimension.is_categorical() and self.secondary_dimension.is_categorical() and secondary_flag:
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.secondary_dimension.field_name, domains[self.secondary_dimension.key]))
-                domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.key)
+                domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.name)
                 queryset_for_others = self.primary_dimension.group_by(queryset_for_others,
                                                                       grouping_key=self.primary_dimension.key,
                                                                       bins=desired_primary_bins)
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
                 results = list(queryset_for_others)
                 for r in results:
-                    r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.key
+                    r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.name
                 return results
 
 

--- a/msgvis/apps/datatable/models.py
+++ b/msgvis/apps/datatable/models.py
@@ -152,9 +152,9 @@ class DataTable(object):
             # on that dimension's group_by() implementation.
 
             queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
-            domains[self.primary_dimension.key].append(u'others')
+            domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
 
-            return [{self.primary_dimension.key: u'others', 'value': queryset_for_others.count()}]
+            return [{self.primary_dimension.key: u'Other ' + self.primary_dimension.key, 'value': queryset_for_others.count()}]
 
         elif self.secondary_dimension:
 
@@ -162,15 +162,15 @@ class DataTable(object):
             if self.primary_dimension.is_categorical() and self.secondary_dimension.is_categorical():
                 original_queryset = queryset_for_others
                 others_results = []
-                domains[self.primary_dimension.key].append(u'others')
-                domains[self.secondary_dimension.key].append(u'others')
+                domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
+                domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.key)
 
                 # primary others x secondary others
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.secondary_dimension.field_name, domains[self.secondary_dimension.key]))
 
-                others_results.append({self.primary_dimension.key: u'others',
-                                       self.secondary_dimension.key: u'others',
+                others_results.append({self.primary_dimension.key: u'Other ' + self.primary_dimension.key,
+                                       self.secondary_dimension.key: u'Other ' + self.secondary_dimension.key,
                                        'value': queryset_for_others.count()})
 
                 # primary top ones x secondary others
@@ -182,10 +182,10 @@ class DataTable(object):
                                                                       grouping_key=self.primary_dimension.key)
 
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
-                primary_top_results = list(queryset_for_others)
-                for r in primary_top_results:
-                    r[self.secondary_dimension.key] = u'others'
-                others_results.extend(primary_top_results)
+                results = list(queryset_for_others)
+                for r in results:
+                    r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.key
+                others_results.extend(results)
 
                 # primary others x secondary top ones
                 queryset_for_others = original_queryset
@@ -196,38 +196,38 @@ class DataTable(object):
                                                                         grouping_key=self.secondary_dimension.key)
 
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
-                secondary_top_results = list(queryset_for_others)
-                for r in secondary_top_results:
-                    r[self.primary_dimension.key] = u'others'
-                others_results.extend(secondary_top_results)
+                results = list(queryset_for_others)
+                for r in results:
+                    r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.key
+                others_results.extend(results)
 
                 return others_results
 
             # primary categorical and secondary quantitative
             elif self.primary_dimension.is_categorical() and not self.secondary_dimension.is_categorical():
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.primary_dimension.field_name, domains[self.primary_dimension.key]))
-                domains[self.primary_dimension.key].append(u'others')
+                domains[self.primary_dimension.key].append(u'Other ' + self.primary_dimension.key)
                 queryset_for_others = self.secondary_dimension.group_by(queryset_for_others,
                                                                         grouping_key=self.secondary_dimension.key,
                                                                         bins=desired_secondary_bins)
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
-                secondary_results = list(queryset_for_others)
-                for r in secondary_results:
-                    r[self.primary_dimension.key] = u'others'
-                return secondary_results
+                results = list(queryset_for_others)
+                for r in results:
+                    r[self.primary_dimension.key] = u'Other ' + self.primary_dimension.key
+                return results
 
             # primary quantitative and secondary categorical
             elif not self.primary_dimension.is_categorical() and self.secondary_dimension.is_categorical():
                 queryset_for_others = queryset_for_others.exclude(levels_or(self.secondary_dimension.field_name, domains[self.secondary_dimension.key]))
-                domains[self.secondary_dimension.key].append(u'others')
+                domains[self.secondary_dimension.key].append(u'Other ' + self.secondary_dimension.key)
                 queryset_for_others = self.primary_dimension.group_by(queryset_for_others,
                                                                       grouping_key=self.primary_dimension.key,
                                                                       bins=desired_primary_bins)
                 queryset_for_others = queryset_for_others.annotate(value=models.Count('id'))
-                primary_results = list(queryset_for_others)
-                for r in primary_results:
-                    r[self.secondary_dimension.key] = u'others'
-                return primary_results
+                results = list(queryset_for_others)
+                for r in results:
+                    r[self.secondary_dimension.key] = u'Other ' + self.secondary_dimension.key
+                return results
 
 
     def domain(self, dimension, queryset, filter=None, exclude=None, desired_bins=None):

--- a/msgvis/apps/dimensions/models.py
+++ b/msgvis/apps/dimensions/models.py
@@ -66,6 +66,10 @@ class CategoricalDimension(object):
                 queryset = queryset.exclude(Q((self.field_name, kwargs['value'])))
         return queryset
 
+    def is_categorical(self):
+        """Return True for real categorical dimensions"""
+        return True
+
     def get_key_model(self):
         dimension_key_model, created = DimensionKey.objects.get_or_create(key=self.key)
         return dimension_key_model
@@ -245,6 +249,9 @@ class QuantitativeDimension(CategoricalDimension):
         self.min_bin_size = min_bin_size
         self._cached_range_queryset_id = None
         self._cached_range = None
+
+    def is_categorical(self):
+        return False
 
     def filter(self, queryset, **kwargs):
         # Type checking

--- a/msgvis/apps/dimensions/registry.py
+++ b/msgvis/apps/dimensions/registry.py
@@ -96,7 +96,7 @@ register(models.RelatedCategoricalDimension, dict(
 
 register(models.CategoricalDimension, dict(
     key='contains_hashtag',
-    name='Contains a hashtag',
+    name='Contains a Hashtag',
     description='Contains any hashtag',
     field_name='contains_hashtag',
     domain=[False, True],
@@ -111,7 +111,7 @@ register(models.RelatedCategoricalDimension, dict(
 
 register(models.CategoricalDimension, dict(
     key='contains_url',
-    name='Contains a url',
+    name='Contains a Url',
     description='Contains a url',
     field_name='contains_url',
     domain=[False, True],
@@ -126,7 +126,7 @@ register(models.RelatedCategoricalDimension, dict(
 
 register(models.CategoricalDimension, dict(
     key='contains_media',
-    name='Contains media',
+    name='Contains Media',
     description='Contains a photo',
     field_name='contains_media',
     domain=[False, True],
@@ -192,7 +192,7 @@ register(models.CategoricalDimension, dict(
 # BEGIN SENDER DIMENSIONS
 register(models.RelatedCategoricalDimension, dict(
     key='sender_name',
-    name='Author name',
+    name='Author Name',
     description='The name of the message author',
     field_name='sender__username',
 ))

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -694,9 +694,9 @@
                     size: {
                         height: 500
                     },
-                    padding: {
-                        //bottom: 80
-                    },
+                    /*padding: {
+                        bottom: 30
+                    },*/
                     data:{
                         type: 'bar',
                         x: primary.key,
@@ -711,7 +711,8 @@
                             label: {
                                 text: primary.name,
                                 position: 'outer-center'
-                            }
+                            },
+                            height: 60
                         },
                         y: {
                             label: {

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -700,7 +700,7 @@
                         names: {
                             value: 'Num. Messages'
                         },
-                        onclick: dataClicked
+                        onclick: dataClicked,
                     },
                     axis:  {
                         x: {
@@ -722,7 +722,6 @@
                     legend: {
                         show: false
                     }
-
                 };
 
                 //If x is quantitative, use a line chart
@@ -774,15 +773,11 @@
                             anchor: 'top-right',
                             x: 20,
                             y: 20,
-                            step: 2
+                            step: 3
                         };
                         var num_of_levels = domains[secondary.key].length;
                         if ( num_of_levels > 12 ){
                             config.legend.inset.step = 6;
-                            //config.legend.inset.y = 450;
-                            //config.padding.bottom = 150;
-
-
                         }
                     }
                 }

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -618,6 +618,15 @@
                 table.forEach(function(row) {
                     var value = row[DEFAULT_VALUE_KEY];
                     var r = rowIndex[self.primaryValueLabel(row[primary.key])];
+                    if ( typeof(r) === "undefined" && primary.is_quantitative() ){
+                        var rowList = Object.keys(rowIndex).sort(function(a, b){return (+a) - (+b);});
+                        for ( var i = 0 ; i < rowList.length ; i++ ){
+                            if ( +rowList[i] < +row[primary.key] ){
+                                r = rowIndex[rowList[i]];
+                                break;
+                            }
+                        }
+                    }
                     var c = 1;
                     if (columnAggregation) {
                         //We are aggregating
@@ -628,9 +637,22 @@
                             //we have secondary dimension values in the headers which means
                             //the column index comes from the data
                             c = columnIndex[self.secondaryValueLabel(row[secondary.key])];
+                            if ( typeof(c) === "undefined" && secondary.is_quantitative() ){
+                                var columnList = Object.keys(columnIndex).sort(function(a, b){return (+a) - (+b);});
+                                for ( var i = 0 ; i < columnList.length ; i++ ){
+                                    if ( +columnList[i] < +row[primary.key] ){
+                                        c = columnIndex[columnList[i]];
+                                        break;
+                                    }
+                                }
+                            }
                         }
-
-                        rows[r][c] = value;
+                        try{
+                            rows[r][c] = value;
+                        }
+                        catch(e){
+                            debugger;
+                        }
                     }
                 });
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -647,12 +647,9 @@
                                 }
                             }
                         }
-                        try{
-                            rows[r][c] = value;
-                        }
-                        catch(e){
-                            debugger;
-                        }
+
+                        rows[r][c] = value;
+
                     }
                 });
 

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -497,7 +497,7 @@
                     }
 
                     if (label === null || label === '') {
-                        label = "No " + dimension.key;
+                        label = "No " + dimension.name;
                     }
 
                     valueLabels[value] = label.toString();

--- a/msgvis/static/SparQs/services.js
+++ b/msgvis/static/SparQs/services.js
@@ -270,7 +270,8 @@
                         dataset: dataset,
                         filters: filters,
                         exclude: exclude,
-                        dimensions: dimension_keys
+                        dimensions: dimension_keys,
+                        mode: "enable_others"
                     };
 
                     var self = this;

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -265,7 +265,7 @@
                         var list = dimension.domain.slice(0);
                         for (var i = 0; i < list.length; i++) {
                             if (list[i] == null)
-                                list[i] = "No " + dimension.key;
+                                list[i] = "No " + dimension.name;
                         }
                         return list;
                     }
@@ -273,7 +273,7 @@
                 },
                 inverse_level: function(level){
                      var dimension = this;
-                    if ( level == "No " + dimension.key )
+                    if ( level == "No " + dimension.name )
                         return "";
                     return level;
                 },
@@ -425,7 +425,7 @@
                 },
                 {
                     "key": "contains_hashtag",
-                    "name": "Contains a hashtag",
+                    "name": "Contains a Hashtag",
                     "type": "CategoricalDimension"
                 },
                 {
@@ -435,12 +435,12 @@
                 },
                 {
                     "key": "contains_url",
-                    "name": "Contains a url",
+                    "name": "Contains a Url",
                     "type": "CategoricalDimension"
                 },
                 {
                     "key": "contains_media",
-                    "name": "Contains a photo",
+                    "name": "Contains a Photo",
                     "type": "CategoricalDimension"
                 },
                 {
@@ -475,12 +475,12 @@
                 },
                 {
                     "key": "contains_mention",
-                    "name": "Contains a mention",
+                    "name": "Contains a Mention",
                     "type": "CategoricalDimension"
                 },
                 {
                     "key": "sender_name",
-                    "name": "Author name",
+                    "name": "Author Name",
                     "type": "CategoricalDimension"
                 },
                 {

--- a/msgvis/static/sparqs.less
+++ b/msgvis/static/sparqs.less
@@ -391,8 +391,12 @@ body {
             fill: none;
         }
         .c3-legend-item text{
-                fill: white;
+            fill: white;
         }
+        .c3-tooltip-container{
+            color: black;
+        }
+
 
     }
 


### PR DESCRIPTION
This is for #90.

Categorical dimensions that have > MAX_CATEGORICAL_LEVELS (current = 10) levels will use "Other <Dimension Name>" to cluster others levels.

This function is enabled by given "mode" = "enable_others" in data table api.

Focus is not working for example messages.