### PR TITLE
Corpus indices

### DIFF
--- a/msgvis/apps/corpus/migrations/0017_auto_20150309_0659.py
+++ b/msgvis/apps/corpus/migrations/0017_auto_20150309_0659.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import msgvis.apps.base.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('corpus', '0016_auto_20150305_2056'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='hashtag',
+            name='text',
+            field=msgvis.apps.base.models.Utf8CharField(max_length=100, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='timezone',
+            name='name',
+            field=models.CharField(max_length=150, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterIndexTogether(
+            name='message',
+            index_together=set([('dataset', 'original_id')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='person',
+            index_together=set([('dataset', 'original_id')]),
+        ),
+    ]

--- a/msgvis/apps/corpus/models.py
+++ b/msgvis/apps/corpus/models.py
@@ -71,7 +71,7 @@ class Url(models.Model):
 class Hashtag(models.Model):
     """A hashtag in a message"""
 
-    text = base_models.Utf8CharField(max_length=100)
+    text = base_models.Utf8CharField(max_length=100, db_index=True)
     """The text of the hashtag, without the hash"""
 
 
@@ -95,13 +95,18 @@ class Timezone(models.Model):
     olson_code = models.CharField(max_length=40, null=True, blank=True, default=None)
     """The timezone code from pytz."""
 
-    name = models.CharField(max_length=150)
+    name = models.CharField(max_length=150, db_index=True)
     """Another name for the timezone, perhaps the country where it is located?"""
 
 class Person(models.Model):
     """
     A person who sends messages in a dataset.
     """
+
+    class Meta:
+        index_together = (
+            ('dataset', 'original_id')  # used by the importer
+        )
 
     dataset = models.ForeignKey(Dataset)
     """Which :class:`Dataset` this person belongs to"""
@@ -144,7 +149,11 @@ class Message(models.Model):
     """
     The Message is the central data entity for the dataset.
     """
-
+    class Meta:
+        index_together = (
+            ('dataset', 'original_id'),  # used by importer
+        )
+            
     dataset = models.ForeignKey(Dataset)
     """Which :class:`Dataset` the message belongs to"""
 


### PR DESCRIPTION
I'll test to see if these actually speed up import before merging, but there are lots of queries by dataset id and original id, so hopefully those would help.

We should also probably cache small-set values like languages, timezones, and message types.

This is related to #124.