### PR TITLE
Add support for caching

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -82,10 +82,10 @@ def load_fixtures():
         fabutils.manage_py('syncdata %s' % (PROJECT_ROOT / fixturefile,))
 
 
-def import_corpus(dataset_file):
+def import_corpus(dataset_file_or_dir):
     """Import a dataset from a file"""
-    dataset_file = path(dataset_file).abspath().realpath()
-    fabutils.manage_py('import_corpus %s' % dataset_file)
+    dataset_file_or_dir = path(dataset_file_or_dir).abspath().realpath()
+    fabutils.manage_py('import_corpus %s' % dataset_file_or_dir)
 
 
 def restart_webserver():

--- a/fabfile.py
+++ b/fabfile.py
@@ -167,3 +167,12 @@ def info():
 
 
 nltk_init = factories.nltk_download_task(required_nltk_corpora)
+
+
+def memcached_status():
+    """Display the status of the memcached server"""
+    denv = fabutils.dot_env(default={})
+    if denv.get('MEMCACHED_LOCATION', None) is not None:
+        local("watch -n1 -d 'memcstat --servers %s'" % denv.get('MEMCACHED_LOCATION', None))
+    else:
+        print yellow("Set MEMCACHED_LOCATION in .env")

--- a/msgvis/apps/base/views.py
+++ b/msgvis/apps/base/views.py
@@ -2,7 +2,7 @@ from django.views import generic
 from django.http import Http404
 from django.utils.translation import ugettext as _
 
-from msgvis.apps.corpus import models
+from msgvis.apps.corpus import models as corpus_models
 
 class HomeView(generic.TemplateView):
     """The homepage view for the website."""
@@ -15,9 +15,12 @@ class ExplorerView(generic.DetailView):
 
     template_name = 'explorer.html'
 
-    model = models.Dataset
     pk_url_kwarg = 'dataset_pk'
     default_dataset_pk = 1
+
+    def get_queryset(self):
+        return corpus_models.Dataset.objects.all()
+
 
     def get_object(self, queryset=None):
 

--- a/msgvis/apps/corpus/models.py
+++ b/msgvis/apps/corpus/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from caching.base import CachingManager, CachingMixin
+
 from msgvis.apps.base import models as base_models
 
 class Dataset(models.Model):
@@ -32,17 +34,19 @@ class Dataset(models.Model):
         return messages.order_by('?')[:10]
 
 
-class MessageType(models.Model):
+class MessageType(CachingMixin, models.Model):
     """The type of a message, e.g. retweet, reply, original, system..."""
 
     name = models.CharField(max_length=100, unique=True)
     """The name of the message type"""
 
+    objects = CachingManager()
+
     def __unicode__(self):
         return self.name
 
 
-class Language(models.Model):
+class Language(CachingMixin, models.Model):
     """Represents the language of a message or a user"""
 
     code = models.SlugField(max_length=10, unique=True)
@@ -50,6 +54,8 @@ class Language(models.Model):
 
     name = models.CharField(max_length=100)
     """The full name of the language"""
+
+    objects = CachingManager()
 
     def __unicode__(self):
         return "%s:%s" % (self.code, self.name)
@@ -87,7 +93,7 @@ class Media(models.Model):
     """A url where the media may be accessed"""
 
 
-class Timezone(models.Model):
+class Timezone(CachingMixin, models.Model):
     """
     The timezone of a message or user
     """
@@ -97,6 +103,9 @@ class Timezone(models.Model):
 
     name = models.CharField(max_length=150)
     """Another name for the timezone, perhaps the country where it is located?"""
+
+    objects = CachingManager()
+
 
 class Person(models.Model):
     """

--- a/msgvis/apps/enhance/models.py
+++ b/msgvis/apps/enhance/models.py
@@ -386,6 +386,7 @@ class MessageTopic(models.Model):
         return examples.order_by('-probability')
 
 
-def set_message_sentiment(message):
+def set_message_sentiment(message, save=True):
     message.sentiment = int(round(textblob.TextBlob(message.text).sentiment.polarity))
-    message.save()
+    if save:
+        message.save()

--- a/msgvis/apps/importer/management/commands/delete_corpus.py
+++ b/msgvis/apps/importer/management/commands/delete_corpus.py
@@ -1,0 +1,44 @@
+from django.core.management.base import BaseCommand, CommandError
+from msgvis.apps.importer.models import create_an_instance_from_json
+from optparse import make_option
+
+from msgvis.apps.corpus.models import Dataset, Hashtag, Url, Media
+
+class Command(BaseCommand):
+    """
+    Import a corpus of message data into the database.
+
+    .. code-block :: bash
+
+        $ python manage.py import_corpus <file_path>
+
+    """
+    args = "<corpus_name_or_id>"
+
+    def handle(self, corpus_name_or_id=None, *args, **options):
+
+        if not corpus_name_or_id:
+            raise CommandError("Corpus name or id must be provided")
+
+        try:
+            corpus_id = int(corpus_name_or_id)
+            dataset = Dataset.objects.get(pk=corpus_id)
+        except ValueError:
+            dataset = Dataset.objects.get(name=corpus_name_or_id)
+
+        print "Deleting dataset %s with %d messages and %d people..." % (dataset.name,
+                                                                         dataset.message_set.count(),
+                                                                         dataset.person_set.count())
+        dataset.delete()
+
+        # Now delete all the unused crap
+        media = Media.objects.filter(message=None)
+        print "Deleting %d unused media..." % media.count()
+        media.delete()
+        
+        hashtags = Hashtag.objects.filter(message=None)
+        print "Deleting %d unused hashtags..." % hashtags.count()
+        hashtags.delete()
+        urls = Url.objects.filter(message=None)
+        print "Deleting %d unused urls..." % urls.count()
+        urls.delete()

--- a/msgvis/apps/importer/management/commands/import_corpus.py
+++ b/msgvis/apps/importer/management/commands/import_corpus.py
@@ -5,6 +5,7 @@ from optparse import make_option
 from msgvis.apps.corpus.models import Dataset
 from django.db import transaction
 import traceback
+import sys
 
 class Command(BaseCommand):
     """
@@ -67,12 +68,14 @@ class Importer(object):
                             self.not_tweets += 1
                     except:
                         self.errors += 1
-                        print "Import error on line %d" % self.line
+                        print >> sys.stderr, "Import error on line %d" % self.line
                         traceback.print_exc()
 
     def run(self):
-
+        from time import time
         transaction_group = []
+
+        start = time()
 
         for json_str in self.fp:
             self.line += 1
@@ -84,9 +87,9 @@ class Importer(object):
                 transaction_group = []
 
             if self.line > 0 and self.line % self.print_every == 0:
-                print "Reached line %d. Imported: %d; Non-tweets: %d; Errors: %d" % (self.line, self.imported, self.not_tweets, self.errors)
+                print "%6.2fs | Reached line %d. Imported: %d; Non-tweets: %d; Errors: %d" % (time() - start, self.line, self.imported, self.not_tweets, self.errors)
 
         if len(transaction_group) >= 0:
             self._import_group(transaction_group)
 
-        print "Finished %d lines. Imported: %d; Non-tweets: %d; Errors: %d" % (self.line, self.imported, self.not_tweets, self.errors)
+        print "%6.2fs | Finished %d lines. Imported: %d; Non-tweets: %d; Errors: %d" % (time() - start, self.line, self.imported, self.not_tweets, self.errors)

--- a/msgvis/apps/importer/management/commands/import_corpus.py
+++ b/msgvis/apps/importer/management/commands/import_corpus.py
@@ -3,6 +3,7 @@ from msgvis.apps.importer.models import create_an_instance_from_json
 from optparse import make_option
 
 from msgvis.apps.corpus.models import Dataset
+from django.db import transaction
 
 
 class Command(BaseCommand):
@@ -30,14 +31,64 @@ class Command(BaseCommand):
             raise CommandError('Corpus filename must be provided.')
 
         dataset = options.get('dataset')
+        import logging
+        l = logging.getLogger('django.db.backends')
+        l.setLevel(logging.DEBUG)
+        l.addHandler(logging.StreamHandler())
+        with open(corpus_filename, 'rb') as fp:
 
-        fp = open(corpus_filename, 'r')
-        if dataset is None:
-            dataset_obj = Dataset.objects.create(name=corpus_filename, description=corpus_filename)
-        else:
-            dataset_obj, created = Dataset.objects.get_or_create(name=dataset, description=dataset)
+            if dataset is None:
+                dataset_obj = Dataset.objects.create(name=corpus_filename, description=corpus_filename)
+            else:
+                dataset_obj, created = Dataset.objects.get_or_create(name=dataset, description=dataset)
 
-        for json_str in iter(lambda: fp.readline(), ''):
-            json_str = json_str.rstrip('\r\n')
-            if len(json_str) > 0:
-                create_an_instance_from_json(json_str, dataset_obj)
+            importer = Importer(fp, dataset_obj)
+            importer.run()
+
+
+class Importer(object):
+    commit_every = 1
+    print_every = 1000
+
+    def __init__(self, fp, dataset):
+        self.fp = fp
+        self.dataset = dataset
+        self.line = 0
+        self.imported = 0
+        self.not_tweets = 0
+        self.errors = 0
+
+    def _import_group(self, lines):
+        with transaction.atomic():
+            for json_str in lines:
+
+                if len(json_str) > 0:
+                    try:
+                        if create_an_instance_from_json(json_str, self.dataset):
+                            self.imported += 1
+                        else:
+                            self.not_tweets += 1
+                    except:
+                        self.errors += 1
+                        print "Import error on line %d" % self.line
+
+    def run(self):
+
+        transaction_group = []
+
+        for json_str in self.fp:
+            self.line += 1
+            json_str = json_str.strip()
+            transaction_group.append(json_str)
+
+            if len(transaction_group) >= self.commit_every:
+                self._import_group(transaction_group)
+                transaction_group = []
+
+            if self.line > 0 and self.line % self.print_every == 0:
+                print "Reached line %d. Imported: %d; Non-tweets: %d; Errors: %d" % (self.line, self.imported, self.not_tweets, self.errors)
+
+        if len(transaction_group) >= 0:
+            self._import_group(transaction_group)
+
+        print "Finished %d lines. Imported: %d; Non-tweets: %d; Errors: %d" % (self.line, self.imported, self.not_tweets, self.errors)

--- a/msgvis/apps/importer/management/commands/import_corpus.py
+++ b/msgvis/apps/importer/management/commands/import_corpus.py
@@ -4,7 +4,7 @@ from optparse import make_option
 
 from msgvis.apps.corpus.models import Dataset
 from django.db import transaction
-
+import traceback
 
 class Command(BaseCommand):
     """
@@ -31,10 +31,7 @@ class Command(BaseCommand):
             raise CommandError('Corpus filename must be provided.')
 
         dataset = options.get('dataset')
-        import logging
-        l = logging.getLogger('django.db.backends')
-        l.setLevel(logging.DEBUG)
-        l.addHandler(logging.StreamHandler())
+
         with open(corpus_filename, 'rb') as fp:
 
             if dataset is None:
@@ -47,7 +44,7 @@ class Command(BaseCommand):
 
 
 class Importer(object):
-    commit_every = 1
+    commit_every = 100
     print_every = 1000
 
     def __init__(self, fp, dataset):
@@ -71,6 +68,7 @@ class Importer(object):
                     except:
                         self.errors += 1
                         print "Import error on line %d" % self.line
+                        traceback.print_exc()
 
     def run(self):
 

--- a/msgvis/apps/importer/models.py
+++ b/msgvis/apps/importer/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+
 from django.utils.timezone import utc
 from urlparse import urlparse
 
@@ -134,7 +134,6 @@ def handle_entities(tweet, entities, dataset_obj):
             mention_obj.save()
             tweet.mentions.add(mention_obj)
 
-# @profile
 def get_or_create_a_tweet_from_json_obj(tweet_data, dataset_obj):
     """
     Given a dataset object, imports a tweet from json object into

--- a/msgvis/apps/importer/models.py
+++ b/msgvis/apps/importer/models.py
@@ -1,4 +1,5 @@
-
+import sys, six
+from django.db import IntegrityError
 from django.utils.timezone import utc
 from urlparse import urlparse
 
@@ -72,7 +73,8 @@ def get_or_create_url(urlblob):
 
 
 def get_or_create_media(mediablob):
-    media, created = Media.objects.get_or_create(type=mediablob['type'], media_url=mediablob['media_url'])
+    media, created = Media.objects.get_or_create(type=mediablob['type'],
+                                                 media_url=mediablob['media_url'])
     return media
 
 
@@ -83,7 +85,7 @@ def handle_reply_to(status_id, user_id, screen_name, dataset_obj):
         'user': {
             'id': user_id,
             'screen_name': screen_name,
-            },
+        },
         'in_reply_to_status_id': None
     }
 
@@ -106,7 +108,6 @@ def handle_retweet(retweeted_status, dataset_obj):
 
 
 def handle_entities(tweet, entities, dataset_obj):
-
     # hashtags
     if entities.get('hashtags') and len(entities['hashtags']) > 0:
         tweet.contains_hashtag = True
@@ -134,6 +135,7 @@ def handle_entities(tweet, entities, dataset_obj):
             mention_obj.save()
             tweet.mentions.add(mention_obj)
 
+
 def get_or_create_a_tweet_from_json_obj(tweet_data, dataset_obj):
     """
     Given a dataset object, imports a tweet from json object into
@@ -142,7 +144,8 @@ def get_or_create_a_tweet_from_json_obj(tweet_data, dataset_obj):
     if 'in_reply_to_status_id' not in tweet_data:
         return None
 
-    tweet, created = Message.objects.get_or_create(dataset=dataset_obj, original_id=tweet_data['id'])
+    tweet, created = Message.objects.get_or_create(dataset=dataset_obj,
+                                                   original_id=tweet_data['id'])
 
     # text
     if tweet_data.get('text'):

--- a/msgvis/settings/common.py
+++ b/msgvis/settings/common.py
@@ -76,6 +76,24 @@ if DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
 
 
 
+########## CACHE CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+
+if get_env_setting('MEMCACHED_LOCATION', '') is not '':
+    CACHES['default'] = {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': get_env_setting('MEMCACHED_LOCATION'),
+        'PREFIX': SITE_NAME + ':',
+    }
+########## END CACHE CONFIGURATION
+
+
+
 ########## GENERAL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#time-zone
 TIME_ZONE = 'UTC'

--- a/msgvis/settings/dev.py
+++ b/msgvis/settings/dev.py
@@ -17,13 +17,3 @@ DEV = True
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 ########## END EMAIL CONFIGURATION
-
-
-########## CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        }
-}
-########## END CACHE CONFIGURATION

--- a/msgvis/settings/test.py
+++ b/msgvis/settings/test.py
@@ -9,8 +9,8 @@ DATABASES = {
         "PASSWORD": "",
         "HOST": "",
         "PORT": "",
-        },
-    }
+    },
+}
 
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,9 @@ Django>=1.7.2
 # Database Adapter
 MySQL-python
 
+# Cache adapter
+python-memcached
+
 # Templates
 django_compressor
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ MySQL-python
 
 # Cache adapter
 python-memcached
+-e git://github.com/jbalogh/django-cache-machine.git#egg=django-cache-machine
 
 # Templates
 django_compressor

--- a/setup/scripts/vagrant/memcached.sh
+++ b/setup/scripts/vagrant/memcached.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt-get install -y memcached libmemcached-tools
+

--- a/setup/scripts/vagrant_provision.sh
+++ b/setup/scripts/vagrant_provision.sh
@@ -25,6 +25,7 @@ TEST_DBNAME=test_$DBNAME
 SCRIPTS_DIR=$PROJECT_ROOT/setup/scripts
 source "${SCRIPTS_DIR}/vagrant/update.sh"
 source "${SCRIPTS_DIR}/vagrant/mysql.sh"
+source "${SCRIPTS_DIR}/vagrant/memcached.sh"
 source "${SCRIPTS_DIR}/vagrant/phpmyadmin.sh"
 source "${SCRIPTS_DIR}/vagrant/scipy.sh"
 source "${SCRIPTS_DIR}/vagrant/bower.sh"

--- a/setup/templates/dot_env
+++ b/setup/templates/dot_env
@@ -14,14 +14,21 @@ PORT={{ PORT }}
 
 DATABASE_URL=mysql://{{ DATABASE_USER }}:{{ DATABASE_PASS }}@{{ DATABASE_HOST }}:{{ DATABASE_PORT }}/{{ DATABASE_NAME}}
 
+# If this is set, will use memcached
+# should be like host:portnum, e.g. localhost:11211
+MEMCACHED_LOCATION={{ MEMCACHED_LOCATION }}
+
+
 SECRET_KEY={{ SECRET_KEY }}
 GOOGLE_ANALYTICS_ID={{ GOOGLE_ANALYTICS_ID }}
+
 
 # Development Settings
 
 # Set these for deployment
 # DEPLOY_HOST=<username>@<hostname>
 # DEPLOY_VIRTUALENV=<virtualenvname>
+
 
 # Production Settings
 


### PR DESCRIPTION
This adds memcached, python-memcached, and django-cache-machine to the project.

A few models in the corpus app have been switched to enable django-cache-machine caching.
I also reorganized the import script for easier profiling to figure out why it is slow.

Caching with locmem or memcached backend made no noticeable difference on a VM, but of course it was already much faster there than on the server.

I did observe that the entity creation steps take about a third of the import time, which is probably because each hashtag/media/url requires creating two rows in the database. Gains could be obtained by bulk-creating this, but I didn't see an easy way to do it.

This is related to #124.