### PR TITLE
fix time axis and tooltip labels plus zones

### DIFF
--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -706,6 +706,7 @@
                             value: 'Num. Messages'
                         },
                         onclick: dataClicked,
+                        xLocaltime: false
                     },
                     axis:  {
                         x: {
@@ -727,6 +728,9 @@
                     },
                     legend: {
                         show: false
+                    },
+                    tooltip: {
+                        
                     }
                 };
 
@@ -743,12 +747,21 @@
                     //Special time-specific overrides
                     if (primary.is_time()) {
                         config.axis.x.type = 'timeseries';
-                        //config.axis.x.tick = {
-                        //    culling: false
-                        //};
-                        //
+
                         //parsing django time values
                         config.data.xFormat = '%Y-%m-%dT%H:%M:%SZ';
+                        
+                        config.axis.x.tick = {
+                            fit: false
+                        };
+
+                        var tooltipDateFormat = d3.time.format('%c');
+                        config.tooltip.format = {
+                            title: function(d) {
+                                return tooltipDateFormat(d);
+                            }
+                        };
+                        
                     }
                 }
 

--- a/msgvis/static/SparQs/controllers.js
+++ b/msgvis/static/SparQs/controllers.js
@@ -338,14 +338,14 @@
         link: function(scope, element, attrs, ngModelController) {
           ngModelController.$parsers.push(function(data) {
             //convert data from view format to model format
-            data = moment(data, "YYYY-MM-DD HH:mm:ss");
-            if (data.isValid()) return data.utc().toDate();
+            data = moment.utc(data, "YYYY-MM-DD HH:mm:ss");
+            if (data.isValid()) return data.toDate();
             else return undefined;
           });
 
           ngModelController.$formatters.push(function(data) {
             //convert data from model format to view format
-              if (data !== undefined) return moment(data).utc().format("YYYY-MM-DD HH:mm:ss"); //converted
+              if (data !== undefined) return moment.utc(data).format("YYYY-MM-DD HH:mm:ss"); //converted
               return data;
           });
         }


### PR DESCRIPTION
Fixes #149. c3 config changes:

- `config.data.xLocaltime=false` means it expects data in UTC, not local
- `config.axis.x.tick.fit=false` means that it will not generate stupid tick values based on the input domain, but will instead use d3.time.scale default ticks
- `config.tooltip.format.title` uses the full date value for the tooltip title

I also fixed the angular date formatting and parsing directive so that it correctly uses `moment.utc()`.