### PR TITLE
Add instrumentation

### DIFF
--- a/msgvis/apps/api/serializers.py
+++ b/msgvis/apps/api/serializers.py
@@ -327,3 +327,13 @@ class DataTableSerializer(serializers.Serializer):
     search_key = serializers.CharField(allow_null=True, allow_blank=True, required=False)
     mode = serializers.CharField(allow_null=True, allow_blank=True, required=False)
     groups = serializers.ListField(child=serializers.IntegerField(), required=False)
+
+class ActionHistorySerializer(serializers.ModelSerializer):
+    created_at = serializers.DateTimeField(required=False)
+    class Meta:
+        model = groups_models.ActionHistory
+        fields = ('id', 'owner', 'type', 'contents', 'created_at', )
+        read_only_fields = ('id', )
+
+class ActionHistoryListSerializer(serializers.Serializer):
+    records = serializers.ListField(child=ActionHistorySerializer(), required=True)

--- a/msgvis/apps/api/urls.py
+++ b/msgvis/apps/api/urls.py
@@ -10,6 +10,7 @@ api_root_urls = {
     'keyword': url(r'^keyword/$', views.KeywordView.as_view(), name='keyword'),
     'group': url(r'^group/$', csrf_exempt(views.GroupView.as_view()), name='group'),
     'research-questions': url(r'^questions/$', views.ResearchQuestionsView.as_view(), name='research-questions'),
+    'action-history': url(r'^history/$', views.ActionHistoryView.as_view(), name='action-history'),
 }
 
 urlpatterns = api_root_urls.values() + [

--- a/msgvis/apps/groups/migrations/0007_actionhistory.py
+++ b/msgvis/apps/groups/migrations/0007_actionhistory.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('groups', '0006_auto_20150908_2327'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ActionHistory',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created_at', models.DateTimeField(default=datetime.datetime(2015, 9, 9, 8, 35, 20, 593700, tzinfo=utc), db_index=True)),
+                ('from_server', models.BooleanField(default=False)),
+                ('type', models.CharField(default=b'', max_length=100, db_index=True, blank=True)),
+                ('contents', models.TextField(default=b'', blank=True)),
+                ('owner', models.ForeignKey(default=None, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/msgvis/apps/groups/migrations/0008_auto_20150909_0835.py
+++ b/msgvis/apps/groups/migrations/0008_auto_20150909_0835.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('groups', '0007_actionhistory'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='actionhistory',
+            name='created_at',
+            field=models.DateTimeField(default=datetime.datetime(2015, 9, 9, 8, 35, 23, 817509, tzinfo=utc), db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/msgvis/apps/groups/models.py
+++ b/msgvis/apps/groups/models.py
@@ -4,6 +4,7 @@ from msgvis.apps.corpus import models as corpus_models
 from msgvis.apps.enhance import models as enhance_models
 from django.contrib.auth.models import User
 import operator
+from django.utils import timezone
 
 class Group(models.Model):
     """
@@ -11,8 +12,10 @@ class Group(models.Model):
     """
 
     owner = models.ForeignKey(User, default=None, null=True)
+    """User"""
 
     order = models.IntegerField(default=0)
+    """The order in a user's group set"""
 
     name = models.CharField(max_length=250, default=None, blank=True)
     """The group name."""
@@ -21,7 +24,7 @@ class Group(models.Model):
     """Which :class:`corpus_models.Dataset` this group belongs to"""
 
     created_at = models.DateTimeField(auto_now_add=True)
-    """Creation time"""
+    """The group created time"""
 
     keywords = models.TextField(default="", blank=True)
     """keywords for including / excluding messages."""
@@ -50,3 +53,18 @@ class Group(models.Model):
     def __unicode__(self):
         return self.__repr__()
 
+class ActionHistory(models.Model):
+    """
+    A model to record history
+    """
+
+    owner = models.ForeignKey(User, default=None, null=True)
+
+    created_at = models.DateTimeField(default=timezone.now(), db_index=True)
+    """Created time"""
+
+    from_server = models.BooleanField(default=False)
+
+    type = models.CharField(max_length=100, default="", blank=True, db_index=True)
+
+    contents = models.TextField(default="", blank=True)

--- a/msgvis/static/SparQs/charts.js
+++ b/msgvis/static/SparQs/charts.js
@@ -552,7 +552,7 @@
 
     module.directive('sparqsVis', function () {
 
-        var SparQsVis = function ($element, attrs, onClicked, groupColor) {
+        var SparQsVis = function (scope, $element, attrs, onClicked, groupColor) {
 
             var DEFAULT_VALUE_KEY = 'value';
 
@@ -917,7 +917,13 @@
                         show: false
                     },
                     tooltip: {
-                        grouped: false // Default true
+                        grouped: false, // Default true
+                        position: function (data, width, height, element) {
+                            var position = $(element).position();
+                            position.top += 20;
+                            position.left += 20;
+                            return position;
+                        }
                     },
                     subchart: {
                         show: function(primary){
@@ -925,6 +931,9 @@
                         }(primary),
                         size: {
                             height: 30
+                        },
+                        onbrush: function (domain) {
+                            scope.$parent.$broadcast('add-history', 'vis:subchart:onbrush', {domain: domain});
                         }
                     },
                     color: {
@@ -1015,9 +1024,11 @@
                                 if (is_shown){
                                     self.chart.hide();
                                     self.chart.show(id);
+                                    scope.$parent.$broadcast('add-history', 'vis:legend:click', {id: id, action:'only-show'});
                                 }
                                 else {
                                     self.chart.show(id);
+                                    scope.$parent.$broadcast('add-history', 'vis:legend:click', {id: id, action:'from-hide-to-show'});
                                 }
                             }
                         };
@@ -1071,7 +1082,7 @@
                     }
                 };
 
-                var vis = scope._sparqsVis = new SparQsVis($element, attrs, onClicked, scope.groupColors);
+                var vis = scope._sparqsVis = new SparQsVis(scope, $element, attrs, onClicked, scope.groupColors);
 
                 // Watch for changes to the datatable
                 scope.$watch('dataTable.table', function (newVals, oldVals) {

--- a/msgvis/static/SparQs/services/dimensions_service.js
+++ b/msgvis/static/SparQs/services/dimensions_service.js
@@ -199,8 +199,8 @@
                             (!this.is_categorical() && this.current_filter().is_empty()));
                 },
                 is_dirty: function(){
-                    console.log("is_dirty is called");
-                    console.log(this.filter_type['filter'].dirty || this.filter_type['exclude'].dirty);
+                    //console.log("is_dirty is called");
+                    //console.log(this.filter_type['filter'].dirty || this.filter_type['exclude'].dirty);
                     return this.filter_type['filter'].dirty ||
                            this.filter_type['exclude'].dirty;
                 },

--- a/msgvis/templates/grouper.html
+++ b/msgvis/templates/grouper.html
@@ -105,6 +105,7 @@
                                       minlength="1"
                                       clear-selected="true"
                                       input-class="input-box"
+                                      input-changed="input_changed"
                                       enter-key-down="press_enter_key"
                                       backspace-key-down="delete_previous_item" />
 
@@ -151,7 +152,7 @@
                                     </div>
 
                                     <div class="keyword-list">
-                                        <strong>Keywords: </strong>{$ group.keywords $}
+                                        <strong>Keywords: </strong>{$ group.keywords.split(',').join(', ') $}
                                     </div>
                                     <div class="type-list">
                                         <strong>Includes: </strong> {$ (group.include_types.length == 0 || group.include_types.length == 3) ? "all types" : group.include_types.join(', ') $}
@@ -194,6 +195,7 @@
                                                   minlength="1"
                                                   clear-selected="true"
                                                   input-class="input-box"
+                                                  input-changed="input_changed"
                                                   enter-key-down="press_enter_key"
                                                   backspace-key-down="delete_previous_item" />
 
@@ -214,7 +216,7 @@
 
                                         <div class="close-btn" ng-show="is_being_editing(group)">
                                             <span class="glyphicon glyphicon-ok" ng-click="save($event, group)" ></span>
-                                            <span class="glyphicon glyphicon-share-alt" ng-click="finish_edit($event)" ></span>
+                                            <span class="glyphicon glyphicon-share-alt" ng-click="finish_edit($event, group)" ></span>
                                         </div>
 
                                     </form>
@@ -242,9 +244,9 @@
                     <div id="search" class="box">
                         <div id="search-tab">
                             <span ng-class="tab_class('keyword_list')"
-                                  ng-click="change_mode('keyword_list')">Keywords</span>
+                                  ng-click="change_mode('keyword_list', $event)">Keywords</span>
                             <span ng-class="tab_class('group_messages')"
-                                  ng-click="change_mode('group_messages')">Search Results</span>
+                                  ng-click="change_mode('group_messages', $event)">Search Results</span>
 
                         </div>
 


### PR DESCRIPTION
This is for #117 

The instrumentation contains both server side and client side.
The server side record will  be saved whenever a REST call is made,
while the client side will save records in a queue and submit to the server every 30 seconds.

To ensure the final records to be saved before close the window, use "/?safe" as suffix to the href.
(e.g. http://localhost:8080/grouper/?safe)
In the safe mode, a pop up dialog will show up to ask if the user really want to leave the page.
Meanwhile, the submit function will be called.

The server side instrumentation is added in [the REST api view](https://github.com/hds-lab/textvisdrg/blob/add-instrumentation/msgvis/apps/api/views.py) with "add_history" function.
The server side instrumentation is mostly added in the [controller.js](https://github.com/hds-lab/textvisdrg/blob/add-instrumentation/msgvis/static/SparQs/controllers.js) with "History.add_record", a service to save the records.

To avoid server side and client side having different time (which happens on my machine), a 'start:server-time' and a 'start:client-time'  records will be inserted to the database when the app is loaded. 